### PR TITLE
Graphic

### DIFF
--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ChangeEventSourceFactory.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ChangeEventSourceFactory.java
@@ -18,41 +18,41 @@ import io.debezium.util.Clock;
 
 public class As400ChangeEventSourceFactory implements ChangeEventSourceFactory<As400Partition, As400OffsetContext> {
 
-	private final As400ConnectorConfig configuration;
-	private final As400ConnectorConfig snapshotConfig;
-	private final As400RpcConnection rpcConnection;
-	private final MainConnectionProvidingConnectionFactory<As400JdbcConnection> jdbcConnectionFactory;
-	private final ErrorHandler errorHandler;
-	private final EventDispatcher<As400Partition, TableId> dispatcher;
-	private final Clock clock;
-	private final As400DatabaseSchema schema;
+    private final As400ConnectorConfig configuration;
+    private final As400ConnectorConfig snapshotConfig;
+    private final As400RpcConnection rpcConnection;
+    private final MainConnectionProvidingConnectionFactory<As400JdbcConnection> jdbcConnectionFactory;
+    private final ErrorHandler errorHandler;
+    private final EventDispatcher<As400Partition, TableId> dispatcher;
+    private final Clock clock;
+    private final As400DatabaseSchema schema;
 
-	public As400ChangeEventSourceFactory(As400ConnectorConfig configuration, As400ConnectorConfig snapshotConfig,
-			As400RpcConnection rpcConnection,
-			MainConnectionProvidingConnectionFactory<As400JdbcConnection> jdbcConnectionFactory,
-			ErrorHandler errorHandler, EventDispatcher<As400Partition, TableId> dispatcher, Clock clock,
-			As400DatabaseSchema schema) {
-		this.configuration = configuration;
-		this.rpcConnection = rpcConnection;
-		this.jdbcConnectionFactory = jdbcConnectionFactory;
-		this.errorHandler = errorHandler;
-		this.dispatcher = dispatcher;
-		this.clock = clock;
-		this.schema = schema;
-		this.snapshotConfig = snapshotConfig;
-	}
+    public As400ChangeEventSourceFactory(As400ConnectorConfig configuration, As400ConnectorConfig snapshotConfig,
+            As400RpcConnection rpcConnection,
+            MainConnectionProvidingConnectionFactory<As400JdbcConnection> jdbcConnectionFactory,
+            ErrorHandler errorHandler, EventDispatcher<As400Partition, TableId> dispatcher, Clock clock,
+            As400DatabaseSchema schema) {
+        this.configuration = configuration;
+        this.rpcConnection = rpcConnection;
+        this.jdbcConnectionFactory = jdbcConnectionFactory;
+        this.errorHandler = errorHandler;
+        this.dispatcher = dispatcher;
+        this.clock = clock;
+        this.schema = schema;
+        this.snapshotConfig = snapshotConfig;
+    }
 
-	@Override
-	public SnapshotChangeEventSource<As400Partition, As400OffsetContext> getSnapshotChangeEventSource(
-			SnapshotProgressListener<As400Partition> snapshotProgressListener,
-			NotificationService<As400Partition, As400OffsetContext> notificationService) {
-		return new As400SnapshotChangeEventSource(snapshotConfig, rpcConnection, jdbcConnectionFactory, schema,
-				dispatcher, clock, snapshotProgressListener, notificationService);
-	}
+    @Override
+    public SnapshotChangeEventSource<As400Partition, As400OffsetContext> getSnapshotChangeEventSource(
+            SnapshotProgressListener<As400Partition> snapshotProgressListener,
+            NotificationService<As400Partition, As400OffsetContext> notificationService) {
+        return new As400SnapshotChangeEventSource(snapshotConfig, rpcConnection, jdbcConnectionFactory, schema,
+                dispatcher, clock, snapshotProgressListener, notificationService);
+    }
 
-	@Override
-	public StreamingChangeEventSource<As400Partition, As400OffsetContext> getStreamingChangeEventSource() {
-		return new As400StreamingChangeEventSource(configuration, rpcConnection, jdbcConnectionFactory.mainConnection(),
-				dispatcher, errorHandler, clock, schema);
-	}
+    @Override
+    public StreamingChangeEventSource<As400Partition, As400OffsetContext> getStreamingChangeEventSource() {
+        return new As400StreamingChangeEventSource(configuration, rpcConnection, jdbcConnectionFactory.mainConnection(),
+                dispatcher, errorHandler, clock, schema);
+    }
 }

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorConfig.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorConfig.java
@@ -96,6 +96,9 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     public static final Field TO_CCSID = Field.create("to_ccsid", "to ccsid", "when the table indicates the from_ccsid translate to this to_ccsid setting", -1);
 
+    public static final Field DIAGNOSTICS_FOLDER = Field.create("diagnostics_folder",
+            "folder to dump failed decodings to", "used when there is a decoding failure to aid diagnostics");
+
     /**
      * Maximum number of journal entries to process server side
      */
@@ -189,6 +192,10 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
         return config.getBoolean(SECURE);
     }
 
+    public String diagnosticsFolder() {
+        return config.getString(DIAGNOSTICS_FOLDER);
+    }
+
     public JournalProcessedPosition getOffset() {
         final String receiver = config.getString(As400OffsetContext.RECEIVER);
         final String lib = config.getString(As400OffsetContext.RECEIVER_LIBRARY);
@@ -224,14 +231,16 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     public static Field.Set ALL_FIELDS = Field.setOf(JdbcConfiguration.HOSTNAME, USER, PASSWORD, SCHEMA, BUFFER_SIZE,
             RelationalDatabaseConnectorConfig.SNAPSHOT_SELECT_STATEMENT_OVERRIDES_BY_TABLE, KEEP_ALIVE, THREAD_USED, SOCKET_TIMEOUT,
-            MAX_SERVER_SIDE_ENTRIES, TOPIC_NAMING_STRATEGY, FROM_CCSID, TO_CCSID, DB_ERRORS, DATE_FORMAT, SECURE);
+            MAX_SERVER_SIDE_ENTRIES, TOPIC_NAMING_STRATEGY, FROM_CCSID, TO_CCSID, DB_ERRORS, DATE_FORMAT, SECURE,
+            DIAGNOSTICS_FOLDER);
 
     public static ConfigDef configDef() {
         final ConfigDef c = RelationalDatabaseConnectorConfig.CONFIG_DEFINITION.edit()
                 .name("ibmi")
                 .type(
                         JdbcConfiguration.HOSTNAME, USER, PASSWORD, SCHEMA, BUFFER_SIZE,
-                        KEEP_ALIVE, THREAD_USED, SOCKET_TIMEOUT, FROM_CCSID, TO_CCSID, DB_ERRORS, DATE_FORMAT, SECURE)
+                        KEEP_ALIVE, THREAD_USED, SOCKET_TIMEOUT, FROM_CCSID, TO_CCSID, DB_ERRORS, DATE_FORMAT, SECURE,
+                        DIAGNOSTICS_FOLDER)
                 .connector()
                 .events(
                         As400OffsetContext.EVENT_SEQUENCE_FIELD,

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400DatabaseSchema.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400DatabaseSchema.java
@@ -26,91 +26,92 @@ import io.debezium.spi.topic.TopicNamingStrategy;
 
 public class As400DatabaseSchema extends RelationalDatabaseSchema implements SchemaCacheIF {
 
-	private static final Logger log = LoggerFactory.getLogger(As400DatabaseSchema.class);
-	private final As400ConnectorConfig config;
-	private final Map<String, TableInfo> map = new HashMap<>();
-	private final As400JdbcConnection jdbcConnection;
-	private final SchemaInfoConversion schemaInfoConversion;
-	private final JdbcFileDecoder fileDecoder;
+    private static final Logger log = LoggerFactory.getLogger(As400DatabaseSchema.class);
+    private final As400ConnectorConfig config;
+    private final Map<String, TableInfo> map = new HashMap<>();
+    private final As400JdbcConnection jdbcConnection;
+    private final SchemaInfoConversion schemaInfoConversion;
+    private final JdbcFileDecoder fileDecoder;
 
-	public As400DatabaseSchema(As400ConnectorConfig config, As400JdbcConnection jdbcConnection,
-			TopicNamingStrategy<TableId> topicSelector, SchemaNameAdjuster schemaNameAdjuster) {
-		super(config, topicSelector, config.getTableFilters().dataCollectionFilter(), config.getColumnFilter(),
-				new TableSchemaBuilder(new As400ValueConverters(), new As400DefaultValueConverter(), schemaNameAdjuster,
-						config.customConverterRegistry(), config.getSourceInfoStructMaker().schema(),
-						config.getFieldNamer(), false),
-				false, config.getKeyMapper());
+    public As400DatabaseSchema(As400ConnectorConfig config, As400JdbcConnection jdbcConnection,
+            TopicNamingStrategy<TableId> topicSelector, SchemaNameAdjuster schemaNameAdjuster) {
+        super(config, topicSelector, config.getTableFilters().dataCollectionFilter(), config.getColumnFilter(),
+                new TableSchemaBuilder(new As400ValueConverters(), new As400DefaultValueConverter(), schemaNameAdjuster,
+                        config.customConverterRegistry(), config.getSourceInfoStructMaker().schema(),
+                        config.getFieldNamer(), false),
+                false, config.getKeyMapper());
 
-		this.config = config;
-		this.jdbcConnection = jdbcConnection;
-		fileDecoder = new JdbcFileDecoder(jdbcConnection, jdbcConnection.getRealDatabaseName(), this,
-				config.getToCcsid());
+        this.config = config;
+        this.jdbcConnection = jdbcConnection;
+        fileDecoder = new JdbcFileDecoder(jdbcConnection, jdbcConnection.getRealDatabaseName(), this,
+                config.getFromCcsid(),
+                config.getToCcsid());
 
-		schemaInfoConversion = new SchemaInfoConversion(fileDecoder);
-	}
+        schemaInfoConversion = new SchemaInfoConversion(fileDecoder);
+    }
 
-	public JdbcFileDecoder getFileDecoder() {
-		return fileDecoder;
-	}
+    public JdbcFileDecoder getFileDecoder() {
+        return fileDecoder;
+    }
 
-	public void clearCache(String systemTableName, String schema) {
-		fileDecoder.clearCache(systemTableName, schema);
-	}
+    public void clearCache(String systemTableName, String schema) {
+        fileDecoder.clearCache(systemTableName, schema);
+    }
 
-	public Optional<TableInfo> getRecordFormat(String systemTableName, String schema) {
-		final Optional<TableInfo> oti = fileDecoder.getRecordFormat(systemTableName, schema);
-		oti.stream().forEach(ti -> {
-			store(jdbcConnection.getRealDatabaseName(), schema, systemTableName, ti);
-		});
-		return oti;
-	}
+    public Optional<TableInfo> getRecordFormat(String systemTableName, String schema) {
+        final Optional<TableInfo> oti = fileDecoder.getRecordFormat(systemTableName, schema);
+        oti.stream().forEach(ti -> {
+            store(jdbcConnection.getRealDatabaseName(), schema, systemTableName, ti);
+        });
+        return oti;
+    }
 
-	// assume always long name - only called from snapshotting
-	public void addSchema(Table table) {
-		final TableId id = table.id();
+    // assume always long name - only called from snapshotting
+    public void addSchema(Table table) {
+        final TableId id = table.id();
 
-		// save for decoding
-		final Optional<String> systemTableNameOpt = jdbcConnection.getSystemName(id.schema(), id.table());
-		systemTableNameOpt.map(systemTableName -> {
-			final TableInfo tableInfo = schemaInfoConversion.table2TableInfo(table);
-			return map.put(toKey(id.catalog(), id.schema(), systemTableName), tableInfo);
-		});
+        // save for decoding
+        final Optional<String> systemTableNameOpt = jdbcConnection.getSystemName(id.schema(), id.table());
+        systemTableNameOpt.map(systemTableName -> {
+            final TableInfo tableInfo = schemaInfoConversion.table2TableInfo(table);
+            return map.put(toKey(id.catalog(), id.schema(), systemTableName), tableInfo);
+        });
 
-		forwardSchema(table);
-	}
+        forwardSchema(table);
+    }
 
-	public void forwardSchema(Table table) {
-		tables().overwriteTable(table);
-		this.buildAndRegisterSchema(table);
-	}
+    public void forwardSchema(Table table) {
+        tables().overwriteTable(table);
+        this.buildAndRegisterSchema(table);
+    }
 
-	public String getSchemaName() {
-		return config.getSchema();
-	}
+    public String getSchemaName() {
+        return config.getSchema();
+    }
 
-	@Override
-	// implements SchemaCacheIF.store - system name tables/column names
-	// assume always short name - only called from the journal
-	public void store(String database, String schema, String tableName, TableInfo tableInfo) {
-		map.put(toKey(database, schema, tableName), tableInfo);
+    @Override
+    // implements SchemaCacheIF.store - system name tables/column names
+    // assume always short name - only called from the journal
+    public void store(String database, String schema, String tableName, TableInfo tableInfo) {
+        map.put(toKey(database, schema, tableName), tableInfo);
 
-		final Table table = SchemaInfoConversion.tableInfo2Table(database, schema, tableName, tableInfo);
-		forwardSchema(table);
-	}
+        final Table table = SchemaInfoConversion.tableInfo2Table(database, schema, tableName, tableInfo);
+        forwardSchema(table);
+    }
 
-	@Override
-	// assume always short name - only called from the journal
-	public TableInfo retrieve(String database, String schema, String tableName) {
-		return map.get(toKey(database, schema, tableName));
-	}
+    @Override
+    // assume always short name - only called from the journal
+    public TableInfo retrieve(String database, String schema, String tableName) {
+        return map.get(toKey(database, schema, tableName));
+    }
 
-	@Override
-	// assume always short name - only called from the journal
-	public void clearCache(String database, String schema, String tableName) {
-		map.remove(toKey(database, schema, tableName));
-	}
+    @Override
+    // assume always short name - only called from the journal
+    public void clearCache(String database, String schema, String tableName) {
+        map.remove(toKey(database, schema, tableName));
+    }
 
-	private String toKey(String database, String schema, String tableName) {
-		return String.format("%s.%s.%s", database, schema, tableName);
-	}
+    private String toKey(String database, String schema, String tableName) {
+        return String.format("%s.%s.%s", database, schema, tableName);
+    }
 }

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400RpcConnection.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400RpcConnection.java
@@ -68,7 +68,7 @@ public class As400RpcConnection implements AutoCloseable, Connect<AS400, IOExcep
                     .withJournalInfo(journalInfo)
                     .withMaxServerSideEntries(config.getMaxServerSideEntries())
                     .withServerFiltering(true)
-                    .withIncludeFiles(includes).build();
+                    .withIncludeFiles(includes).withDumpFolder(config.diagnosticsFolder()).build();
             retrieveJournal = new RetrieveJournal(rconfig, journalInfoRetrieval);
         }
         catch (final IOException e) {

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400StreamingChangeEventSource.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400StreamingChangeEventSource.java
@@ -42,286 +42,285 @@ import io.debezium.util.Metronome;
  * </p>
  */
 public class As400StreamingChangeEventSource implements StreamingChangeEventSource<As400Partition, As400OffsetContext> {
-	private static final String NO_TRANSACTION_ID = "00000000000000000000";
-	private long connectionTime = -1;
-	private final long MIN_DISCONNECT_TIME_MS = 30000;
+    private static final String NO_TRANSACTION_ID = "00000000000000000000";
+    private long connectionTime = -1;
+    private final long MIN_DISCONNECT_TIME_MS = 30000;
 
-	private static final Logger log = LoggerFactory.getLogger(As400StreamingChangeEventSource.class);
+    private static final Logger log = LoggerFactory.getLogger(As400StreamingChangeEventSource.class);
 
-	private final HashMap<String, Object[]> beforeMap = new HashMap<>();
-	private static Set<Character> alwaysProcess = Stream.of('J', 'C').collect(Collectors.toCollection(HashSet::new));
+    private final HashMap<String, Object[]> beforeMap = new HashMap<>();
+    private static Set<Character> alwaysProcess = Stream.of('J', 'C').collect(Collectors.toCollection(HashSet::new));
 
-	/**
-	 * Connection used for reading CDC tables.
-	 */
-	private final As400RpcConnection dataConnection;
-	private final As400JdbcConnection jdbcConnection;
+    /**
+     * Connection used for reading CDC tables.
+     */
+    private final As400RpcConnection dataConnection;
+    private final As400JdbcConnection jdbcConnection;
 
-	/**
-	 * A separate connection for retrieving timestamps; without it, adaptive
-	 * buffering will not work.
-	 */
-	private final EventDispatcher<As400Partition, TableId> dispatcher;
-	private final ErrorHandler errorHandler;
-	private final Clock clock;
-	private final As400DatabaseSchema schema;
-	private final Duration pollInterval;
-	private final As400ConnectorConfig connectorConfig;
-	private final Map<String, TransactionContext> txMap = new HashMap<>();
-	private final String database;
+    /**
+     * A separate connection for retrieving timestamps; without it, adaptive
+     * buffering will not work.
+     */
+    private final EventDispatcher<As400Partition, TableId> dispatcher;
+    private final ErrorHandler errorHandler;
+    private final Clock clock;
+    private final As400DatabaseSchema schema;
+    private final Duration pollInterval;
+    private final As400ConnectorConfig connectorConfig;
+    private final Map<String, TransactionContext> txMap = new HashMap<>();
+    private final String database;
 
-	public As400StreamingChangeEventSource(As400ConnectorConfig connectorConfig, As400RpcConnection dataConnection,
-			As400JdbcConnection jdbcConnection, EventDispatcher<As400Partition, TableId> dispatcher,
-			ErrorHandler errorHandler, Clock clock, As400DatabaseSchema schema) {
-		this.connectorConfig = connectorConfig;
-		this.dataConnection = dataConnection;
-		this.jdbcConnection = jdbcConnection;
-		this.dispatcher = dispatcher;
-		this.errorHandler = errorHandler;
-		this.clock = clock;
-		this.schema = schema;
-		this.pollInterval = connectorConfig.getPollInterval();
-		this.database = jdbcConnection.getRealDatabaseName();
-	}
+    public As400StreamingChangeEventSource(As400ConnectorConfig connectorConfig, As400RpcConnection dataConnection,
+            As400JdbcConnection jdbcConnection, EventDispatcher<As400Partition, TableId> dispatcher,
+            ErrorHandler errorHandler, Clock clock, As400DatabaseSchema schema) {
+        this.connectorConfig = connectorConfig;
+        this.dataConnection = dataConnection;
+        this.jdbcConnection = jdbcConnection;
+        this.dispatcher = dispatcher;
+        this.errorHandler = errorHandler;
+        this.clock = clock;
+        this.schema = schema;
+        this.pollInterval = connectorConfig.getPollInterval();
+        this.database = jdbcConnection.getRealDatabaseName();
+    }
 
-	private void cacheBefore(TableId tableId, Object[] dataBefore) {
-		final String key = String.format("%s-%s", tableId.schema(), tableId.table());
-		beforeMap.put(key, dataBefore);
-	}
+    private void cacheBefore(TableId tableId, Object[] dataBefore) {
+        final String key = String.format("%s-%s", tableId.schema(), tableId.table());
+        beforeMap.put(key, dataBefore);
+    }
 
-	private Object[] getBefore(TableId tableId) {
-		final String key = String.format("%s-%s", tableId.schema(), tableId.table());
-		final Object[] dataBefore = beforeMap.remove(key);
-		if (dataBefore == null) {
-			log.debug("before image not found for {}", key);
-		} else {
-			log.debug("found before image for {}", key);
-		}
-		return dataBefore;
-	}
+    private Object[] getBefore(TableId tableId) {
+        final String key = String.format("%s-%s", tableId.schema(), tableId.table());
+        final Object[] dataBefore = beforeMap.remove(key);
+        if (dataBefore == null) {
+            log.debug("before image not found for {}", key);
+        } else {
+            log.debug("found before image for {}", key);
+        }
+        return dataBefore;
+    }
 
-	@Override
-	public void execute(ChangeEventSourceContext context, As400Partition partition, As400OffsetContext offsetContext)
-			throws InterruptedException {
-		final Metronome metronome = Metronome.sleeper(pollInterval, clock);
-		int retries = 0;
-		final WatchDog watchDog = new WatchDog(Thread.currentThread(), connectorConfig.getMaxRetrievalTimeout());
-		watchDog.start();
-		try {
-			while (context.isRunning()) {
-				try {
-					try {
-						final JournalProcessedPosition before = new JournalProcessedPosition(offsetContext.getPosition());
-						if (!dataConnection.getJournalEntries(context, offsetContext,
-								processJournalEntries(partition, offsetContext), watchDog)) {
-							metronome.pause();
-						}
-						if (!offsetContext.getPosition().equals(before)) {
-							dispatcher.dispatchHeartbeatEvent(partition, offsetContext);
-						}
-						retries = 0;
-					} catch (final FatalException e) {
-						log.error("Unable to process offset {}", offsetContext.getPosition(), e);
-						throw new DebeziumException("Unable to process offset " + offsetContext.getPosition(), e);
-					} catch (final InvalidPositionException e) {
-						log.error("Invalid position resetting offsets to beginning", e);
-						offsetContext.setPosition(new JournalProcessedPosition());
-					} catch (final InterruptedException e) {
-						if (context.isRunning()) {
-							log.error("Interrupted processing offset {} retry {}", offsetContext.getPosition(), retries);
-							closeAndReconnect();
-							retries++;
-							metronome.pause();
-						}
-					} catch (IOException | SQLNonTransientConnectionException e) { // SQLNonTransientConnectionException
-						// thrown by jt400 jdbc driver when
-						// connection errors
-						log.error("Connection failed offset {} retry {}", offsetContext.getPosition(), retries, e);
-						closeAndReconnect();
+    @Override
+    public void execute(ChangeEventSourceContext context, As400Partition partition, As400OffsetContext offsetContext)
+            throws InterruptedException {
+        final Metronome metronome = Metronome.sleeper(pollInterval, clock);
+        int retries = 0;
+        final WatchDog watchDog = new WatchDog(Thread.currentThread(), connectorConfig.getMaxRetrievalTimeout());
+        watchDog.start();
+        try {
+            while (context.isRunning()) {
+                try {
+                    try {
+                        final JournalProcessedPosition before = new JournalProcessedPosition(offsetContext.getPosition());
+                        if (!dataConnection.getJournalEntries(context, offsetContext,
+                                processJournalEntries(partition, offsetContext), watchDog)) {
+                            metronome.pause();
+                        }
+                        if (!offsetContext.getPosition().equals(before)) {
+                            dispatcher.dispatchHeartbeatEvent(partition, offsetContext);
+                        }
+                        retries = 0;
+                    } catch (final FatalException e) {
+                        log.error("Unable to process offset {}", offsetContext.getPosition(), e);
+                        throw new DebeziumException("Unable to process offset " + offsetContext.getPosition(), e);
+                    } catch (final InvalidPositionException e) {
+                        log.error("Invalid position resetting offsets to beginning", e);
+                        offsetContext.setPosition(new JournalProcessedPosition());
+                    } catch (final InterruptedException e) {
+                        if (context.isRunning()) {
+                            log.error("Interrupted processing offset {} retry {}", offsetContext.getPosition(), retries);
+                            closeAndReconnect();
+                            retries++;
+                            metronome.pause();
+                        }
+                    } catch (IOException | SQLNonTransientConnectionException e) { // SQLNonTransientConnectionException
+                        // thrown by jt400 jdbc driver when
+                        // connection errors
+                        log.error("Connection failed offset {} retry {}", offsetContext.getPosition(), retries, e);
+                        closeAndReconnect();
 
-						retries++;
-						metronome.pause(); // throws interruptedException
-					} catch (final Exception e) {
-						log.error("Failed to process offset {} retry {}", offsetContext.getPosition(), retries, e);
+                        retries++;
+                        metronome.pause(); // throws interruptedException
+                    } catch (final Exception e) {
+                        log.error("Failed to process offset {} retry {}", offsetContext.getPosition(), retries, e);
 
-						retries++;
-						metronome.pause();
-					}
-				} catch (final InterruptedException e) { // handle InterruptedException during the exception handling
-					if (context.isRunning()) {
-						log.debug("Interrupted", e);
-					}
-				}
-			}
-		} finally {
-			watchDog.stop();
-		}
-	}
+                        retries++;
+                        metronome.pause();
+                    }
+                } catch (final InterruptedException e) { // handle InterruptedException during the exception handling
+                    if (context.isRunning()) {
+                        log.debug("Interrupted", e);
+                    }
+                }
+            }
+        } finally {
+            watchDog.stop();
+        }
+    }
 
-	public void rateLimittedClose() {
-		if (System.currentTimeMillis() - connectionTime > MIN_DISCONNECT_TIME_MS) {
-			closeAndReconnect();
-		} else {
-			log.debug("Only connected since {} ignoring disconnect", new Date(connectionTime));
-		}
-	}
+    public void rateLimittedClose() {
+        if (System.currentTimeMillis() - connectionTime > MIN_DISCONNECT_TIME_MS) {
+            closeAndReconnect();
+        } else {
+            log.debug("Only connected since {} ignoring disconnect", new Date(connectionTime));
+        }
+    }
 
-	public void closeAndReconnect() {
-		try {
-			dataConnection.close();
-			dataConnection.connection();
-		} catch (final Exception e) {
-			log.error("Failure reconnecting command", e);
-		}
-		try {
-			jdbcConnection.close();
-			jdbcConnection.connect();
-		} catch (final Exception e) {
-			log.error("Failure reconnecting sql", e);
-		}
-		connectionTime = System.currentTimeMillis();
-	}
+    public void closeAndReconnect() {
+        try {
+            dataConnection.close();
+            dataConnection.connection();
+        } catch (final Exception e) {
+            log.error("Failure reconnecting command", e);
+        }
+        try {
+            jdbcConnection.close();
+            jdbcConnection.connect();
+        } catch (final Exception e) {
+            log.error("Failure reconnecting sql", e);
+        }
+        connectionTime = System.currentTimeMillis();
+    }
 
-	// TODO tidy up exception handling
-	private BlockingReceiverConsumer processJournalEntries(As400Partition partition, As400OffsetContext offsetContext)
-			throws IOException, SQLNonTransientConnectionException {
-		return (nextOffset, r, eheader) -> {
-			try {
-				final JournalEntryType journalEntryType = eheader.getJournalEntryType();
+    // TODO tidy up exception handling
+    private BlockingReceiverConsumer processJournalEntries(As400Partition partition, As400OffsetContext offsetContext)
+            throws IOException, SQLNonTransientConnectionException {
+        return (nextOffset, r, eheader) -> {
+            try {
+                final JournalEntryType journalEntryType = eheader.getJournalEntryType();
 
-				if (journalEntryType == null || ignore(journalEntryType)) {
-					log.debug("excluding table {} entry type {}", eheader.getFile(), eheader.getEntryType());
-					return;
-				}
+                if (journalEntryType == null || ignore(journalEntryType)) {
+                    log.debug("excluding table {} entry type {}", eheader.getFile(), eheader.getEntryType());
+                    return;
+                }
 
-				String longName = eheader.getFile();
-				try {
-					longName = jdbcConnection.getLongName(eheader.getLibrary(), eheader.getFile());
-				} catch (final IllegalStateException e) {
-					log.error("failed to look up long name", e);
-				}
-				final TableId tableId = new TableId(database, eheader.getLibrary(), longName);
+                String longName = eheader.getFile();
+                try {
+                    longName = jdbcConnection.getLongName(eheader.getLibrary(), eheader.getFile());
+                } catch (final IllegalStateException e) {
+                    log.error("failed to look up long name", e);
+                }
+                final TableId tableId = new TableId(database, eheader.getLibrary(), longName);
 
-				final boolean includeTable = connectorConfig.getTableFilters().dataCollectionFilter()
-						.isIncluded(tableId);
+                final boolean includeTable = connectorConfig.getTableFilters().dataCollectionFilter()
+                        .isIncluded(tableId);
 
-				if (!alwaysProcess.contains(eheader.getJournalCode()) && !includeTable) { // always process journal J
-					// and transaction C
-					// messages
-					log.debug("excluding table {} journal code {}", tableId, eheader.getJournalCode());
-					return;
-				}
+                if (!alwaysProcess.contains(eheader.getJournalCode()) && !includeTable) { // always process journal J
+                    // and transaction C
+                    // messages
+                    log.debug("excluding table {} journal code {}", tableId, eheader.getJournalCode());
+                    return;
+                }
 
-				log.debug("next event: {} - {} type: {} table: {}", eheader.getTime(), eheader.getSequenceNumber(),
-						eheader.getEntryType(), tableId.table());
-				switch (journalEntryType) {
-				case START_COMMIT: {
-					// start commit
-					final String txId = eheader.getCommitCycle().toString();
-					log.debug("begin transaction: {}", txId);
-					final TransactionContext txc = new TransactionContext();
-					txc.beginTransaction(txId);
-					txMap.put(txId, txc);
-					log.debug("start transaction id {} tx {} table {}", nextOffset, txId, tableId);
-					dispatcher.dispatchTransactionStartedEvent(partition, txId, offsetContext,
-							eheader.getTime());
-				}
-				break;
-				case END_COMMIT: {
-					// end commit
-					// TOOD transaction must be provided by the OffsetContext
-					final String txId = eheader.getCommitCycle().toString();
-					final TransactionContext txc = txMap.remove(txId);
-					log.debug("commit transaction id {} tx {} table {}", nextOffset, txId, tableId);
-					if (txc != null) {
-						txc.endTransaction();
-						dispatcher.dispatchTransactionCommittedEvent(partition, offsetContext,
-								eheader.getTime());
-					}
-				}
-				break;
-				case FILE_CHANGE, FILE_CREATED: {
-					// table has changed - reload schema
-					schema.clearCache(tableId.table(), tableId.schema());
-					schema.getRecordFormat(tableId.table(), tableId.schema());
-				}
-				break;
-				case BEFORE_IMAGE: {
-					// before image
-					tableId.schema();
-					final Object[] dataBefore = r.decode(schema.getFileDecoder());
+                log.debug("next event: {} - {} type: {} table: {}", eheader.getTime(), eheader.getSequenceNumber(),
+                        eheader.getEntryType(), tableId.table());
+                switch (journalEntryType) {
+                case START_COMMIT: {
+                    // start commit
+                    final String txId = eheader.getCommitCycle().toString();
+                    log.debug("begin transaction: {}", txId);
+                    final TransactionContext txc = new TransactionContext();
+                    txc.beginTransaction(txId);
+                    txMap.put(txId, txc);
+                    log.debug("start transaction id {} tx {} table {}", nextOffset, txId, tableId);
+                    dispatcher.dispatchTransactionStartedEvent(partition, txId, offsetContext,
+                            eheader.getTime());
+                }
+                break;
+                case END_COMMIT: {
+                    // end commit
+                    // TOOD transaction must be provided by the OffsetContext
+                    final String txId = eheader.getCommitCycle().toString();
+                    final TransactionContext txc = txMap.remove(txId);
+                    log.debug("commit transaction id {} tx {} table {}", nextOffset, txId, tableId);
+                    if (txc != null) {
+                        txc.endTransaction();
+                        dispatcher.dispatchTransactionCommittedEvent(partition, offsetContext,
+                                eheader.getTime());
+                    }
+                }
+                break;
+                case FILE_CHANGE, FILE_CREATED: {
+                    // table has changed - reload schema
+                    schema.clearCache(tableId.table(), tableId.schema());
+                    schema.getRecordFormat(tableId.table(), tableId.schema());
+                }
+                break;
+                case BEFORE_IMAGE: {
+                    // before image
+                    tableId.schema();
+                    final Object[] dataBefore = r.decode(schema.getFileDecoder());
 
-					cacheBefore(tableId, dataBefore);
-				}
-				break;
-				case AFTER_IMAGE: {
-					// after image
-					// before image is meant to have been immediately before
-					final Object[] dataBefore = getBefore(tableId);
-					final Object[] dataNext = r.decode(schema.getFileDecoder());
+                    cacheBefore(tableId, dataBefore);
+                }
+                break;
+                case AFTER_IMAGE: {
+                    // after image
+                    // before image is meant to have been immediately before
+                    final Object[] dataBefore = getBefore(tableId);
+                    final Object[] dataNext = r.decode(schema.getFileDecoder());
 
-					offsetContext.setSourceTime(eheader.getTime());
+                    offsetContext.setSourceTime(eheader.getTime());
 
-					final String txId = eheader.getCommitCycle().toString();
-					final TransactionContext txc = txMap.get(txId);
-					offsetContext.setTransaction(txc);
+                    final String txId = eheader.getCommitCycle().toString();
+                    final TransactionContext txc = txMap.get(txId);
+                    offsetContext.setTransaction(txc);
 
-					log.debug("update event id {} tx {} table {}", nextOffset, txId, tableId);
+                    log.debug("update event id {} tx {} table {}", nextOffset, txId, tableId);
 
-					dispatcher.dispatchDataChangeEvent(partition, tableId, new As400ChangeRecordEmitter(partition,
-							offsetContext, Operation.UPDATE, dataBefore, dataNext, clock, connectorConfig));
-				}
-				break;
-				case ADD_ROW1, ADD_ROW2: {
-					// record added
-					final Object[] dataNext = r.decode(schema.getFileDecoder());
-					offsetContext.setSourceTime(eheader.getTime());
+                    dispatcher.dispatchDataChangeEvent(partition, tableId, new As400ChangeRecordEmitter(partition,
+                            offsetContext, Operation.UPDATE, dataBefore, dataNext, clock, connectorConfig));
+                }
+                break;
+                case ADD_ROW1, ADD_ROW2: {
+                    // record added
+                    final Object[] dataNext = r.decode(schema.getFileDecoder());
+                    offsetContext.setSourceTime(eheader.getTime());
 
-					final String txId = eheader.getCommitCycle().toString();
-					final TransactionContext txc = txMap.get(txId);
-					offsetContext.setTransaction(txc);
-					if (txc != null) {
-						txc.event(tableId);
-					}
+                    final String txId = eheader.getCommitCycle().toString();
+                    final TransactionContext txc = txMap.get(txId);
+                    offsetContext.setTransaction(txc);
+                    if (txc != null) {
+                        txc.event(tableId);
+                    }
 
-					log.debug("insert event id {} tx {} table {}", offsetContext.getPosition(), txId,
-							tableId);
-					dispatcher.dispatchDataChangeEvent(partition, tableId, new As400ChangeRecordEmitter(partition,
-							offsetContext, Operation.CREATE, null, dataNext, clock, connectorConfig));
-				}
-				break;
-				case DELETE_ROW1, DELETE_ROW2: {
-					// record deleted
-					final Object[] dataBefore = r.decode(schema.getFileDecoder());
+                    log.debug("insert event id {} tx {} table {}", offsetContext.getPosition(), txId,
+                            tableId);
+                    dispatcher.dispatchDataChangeEvent(partition, tableId, new As400ChangeRecordEmitter(partition,
+                            offsetContext, Operation.CREATE, null, dataNext, clock, connectorConfig));
+                }
+                break;
+                case DELETE_ROW1, DELETE_ROW2: {
+                    // record deleted
+                    final Object[] dataBefore = r.decode(schema.getFileDecoder());
 
-					offsetContext.setSourceTime(eheader.getTime());
+                    offsetContext.setSourceTime(eheader.getTime());
 
-					final String txId = eheader.getCommitCycle().toString();
-					final TransactionContext txc = txMap.get(txId);
-					offsetContext.setTransaction(txc);
-					if (txc != null) {
-						txc.event(tableId);
-					}
+                    final String txId = eheader.getCommitCycle().toString();
+                    final TransactionContext txc = txMap.get(txId);
+                    offsetContext.setTransaction(txc);
+                    if (txc != null) {
+                        txc.event(tableId);
+                    }
 
-					log.debug("delete event id {} tx {} table {}", offsetContext.getPosition(), txId,
-							tableId);
-					dispatcher.dispatchDataChangeEvent(partition, tableId, new As400ChangeRecordEmitter(partition,
-							offsetContext, Operation.DELETE, dataBefore, null, clock, connectorConfig));
-				}
-				break;
-				default:
-					break;
-				}
-			} catch (IOException | SQLNonTransientConnectionException e) {
-				throw e;
-			} catch (final Exception e) {
-				log.error("Failed to process record", e);
-			}
-		};
-	}
+                    log.debug("delete event id {} tx {} table {}", offsetContext.getPosition(), txId,
+                            tableId);
+                    dispatcher.dispatchDataChangeEvent(partition, tableId, new As400ChangeRecordEmitter(partition,
+                            offsetContext, Operation.DELETE, dataBefore, null, clock, connectorConfig));
+                }
+                break;
+                default:
+                    break;
+                }
+            } catch (IOException | SQLNonTransientConnectionException e) {
+                throw e;
+            } catch (final Exception e) {
+                log.error("Failed to process record", e);
+            }
+        };
+    }
 
-	private boolean ignore(JournalEntryType journalCode) {
-		return journalCode == JournalEntryType.OPEN || journalCode == JournalEntryType.CLOSE;
-	}
-
+    private boolean ignore(JournalEntryType journalCode) {
+        return journalCode == JournalEntryType.OPEN || journalCode == JournalEntryType.CLOSE;
+    }
 }

--- a/journal-parsing/src/it/java/com/fnz/db2/journal/retrieve/ITRetrievalHelper.java
+++ b/journal-parsing/src/it/java/com/fnz/db2/journal/retrieve/ITRetrievalHelper.java
@@ -45,7 +45,7 @@ public class ITRetrievalHelper {
 		this.maxEntries = maxEntries;
 		this.journalEntryFunction = journalEntryFunction;
 		tables = includes.stream().map(FileFilter::table).collect(Collectors.toSet());
-		fileDecoder = new JdbcFileDecoder(connector.getJdbc(), "databasename", schemaCache, -1);
+		fileDecoder = new JdbcFileDecoder(connector.getJdbc(), "databasename", schemaCache, -1, -1);
 		this.fetchedEntries = fetchedEntries;
 		final RetrieveConfig config = new RetrieveConfigBuilder().withAs400(connector.getAs400())
 				.withJournalInfo(journal).withJournalBufferSize(bufferSize).withServerFiltering(true)

--- a/journal-parsing/src/it/java/com/fnz/db2/journal/retrieve/JdbcFileDecoderIT.java
+++ b/journal-parsing/src/it/java/com/fnz/db2/journal/retrieve/JdbcFileDecoderIT.java
@@ -24,30 +24,30 @@ public class JdbcFileDecoderIT {
 
 	static Connect<Connection, SQLException> sqlConnect;
 	static String database;
-	
+
 	static String schema = "MSDECODER";
 
 	@BeforeAll
 	public static void setup() throws Exception {
-        TestConnector connector = new TestConnector();
-        sqlConnect = connector.getJdbc();
-        database = JdbcFileDecoder.getDatabaseName(sqlConnect.connection());
-        
-        setupSchemaAndTable();
+		final TestConnector connector = new TestConnector();
+		sqlConnect = connector.getJdbc();
+		database = JdbcFileDecoder.getDatabaseName(sqlConnect.connection());
+
+		setupSchemaAndTable();
 	}
 
 
 	@Test
 	void testToDataType() throws Exception {
-		JdbcFileDecoder decoder = new JdbcFileDecoder(sqlConnect, database, new SchemaCacheHash(), -1);
-		Optional<TableInfo> info = decoder.getRecordFormat("DCDTBL", schema);
+		final JdbcFileDecoder decoder = new JdbcFileDecoder(sqlConnect, database, new SchemaCacheHash(), -1, -1);
+		final Optional<TableInfo> info = decoder.getRecordFormat("DCDTBL", schema);
 		assertTrue(info.isPresent());
 		assertEquals(List.of("ID"), info.get().getPrimaryKeys());
 	}
-	
-	
+
+
 	public static void setupSchemaAndTable() throws SQLException {
-		Connection con = sqlConnect.connection(); // debezium doesn't close connections
+		final Connection con = sqlConnect.connection(); // debezium doesn't close connections
 		try (Statement stmt = con.createStatement()) {
 			createSchema(stmt);
 			createEmptyTable(stmt);
@@ -60,7 +60,7 @@ public class JdbcFileDecoderIT {
 		try (ResultSet rs = stmt
 				.executeQuery("select count(1) from qsys2.systables where table_schema='MSDECODER'")) {
 			if (rs.next()) {
-				int found = rs.getInt(1);
+				final int found = rs.getInt(1);
 				if (found < 1) {
 					log.debug("create schema");
 					stmt.executeUpdate("create schema MSDECODER");
@@ -68,11 +68,11 @@ public class JdbcFileDecoderIT {
 			}
 		}
 	}
-	
+
 	private static void createEmptyTable(Statement stmt) throws SQLException {
 		try {
 			stmt.executeUpdate("drop TABLE MSDECODER.DCDTBL");
-		} catch (SQLException e) {
+		} catch (final SQLException e) {
 			// ignore we don't care if it doesn't exist yet
 		}
 

--- a/journal-parsing/src/it/java/com/fnz/db2/journal/retrieve/JournalEntryCcsidIT.java
+++ b/journal-parsing/src/it/java/com/fnz/db2/journal/retrieve/JournalEntryCcsidIT.java
@@ -32,77 +32,77 @@ import com.ibm.as400.access.AS400Text;
 // this file is utf-8
 
 class JournalEntryCcsidIT {
-    private static final String SPECIAL_CHARACTERS = "£$[^~?¢";
+	private static final String SPECIAL_CHARACTERS = "£$[^~?¢";
 
 	private static final Logger log = LoggerFactory.getLogger(JournalEntryCcsidIT.class);
 
 	static Connect<AS400, IOException> as400Connect;
 	static Connect<Connection, SQLException> sqlConnect;
-	
+
 	static String schema = "MSTYPE1";
 
 	@BeforeAll
 	public static void setup() throws Exception {
-        TestConnector connector = new TestConnector();
-        as400Connect = connector.getAs400();
-        sqlConnect = connector.getJdbc();
-        
-        setupSchemaAndTable();
+		final TestConnector connector = new TestConnector();
+		as400Connect = connector.getAs400();
+		sqlConnect = connector.getJdbc();
+
+		setupSchemaAndTable();
 	}
 
 	@Test
 	public void testCcsid() throws Exception {
-		JournalInfoRetrieval journalInfoRetrieval = new JournalInfoRetrieval();
-		JournalInfo journal = JournalInfoRetrieval.getJournal(as400Connect.connection(), schema);
-		Instant now = Instant.now();
-		JournalPosition current = journalInfoRetrieval.getCurrentPosition(as400Connect.connection(), journal);
-		JournalProcessedPosition position = new JournalProcessedPosition(current, now, true);
-		System.out.println("starting at " + position);
+		final JournalInfoRetrieval journalInfoRetrieval = new JournalInfoRetrieval();
+		final JournalInfo journal = JournalInfoRetrieval.getJournal(as400Connect.connection(), schema);
+		final Instant now = Instant.now();
+		final JournalPosition current = journalInfoRetrieval.getCurrentPosition(as400Connect.connection(), journal);
+		final JournalProcessedPosition position = new JournalProcessedPosition(current, now, true);
+		log.debug("starting at {}", position);
 
 		insertData();
 
-		RetrieveConfig config = new RetrieveConfigBuilder().withAs400(as400Connect).withJournalInfo(journal).build();
-		RetrieveJournal rj = new RetrieveJournal(config, journalInfoRetrieval);
-		
-		SchemaCacheHash schemaHash = new SchemaCacheHash();
+		final RetrieveConfig config = new RetrieveConfigBuilder().withAs400(as400Connect).withJournalInfo(journal).build();
+		final RetrieveJournal rj = new RetrieveJournal(config, journalInfoRetrieval);
 
-        String database = JdbcFileDecoder.getDatabaseName(sqlConnect.connection());
-        JdbcFileDecoder fileDecoder = new JdbcFileDecoder(sqlConnect, database, schemaHash, -1);
+		final SchemaCacheHash schemaHash = new SchemaCacheHash();
+
+		final String database = JdbcFileDecoder.getDatabaseName(sqlConnect.connection());
+		final JdbcFileDecoder fileDecoder = new JdbcFileDecoder(sqlConnect, database, schemaHash, -1, -1);
 		boolean foundInsert = false;
 		boolean success = true;
-	
+
 		for (int i=0; success && !foundInsert && i < 100; i++) { // journal entries are not available straight away
 			success = rj.retrieveJournal(position);
-			System.out.println(position+ " : " + success);
+			log.debug("position {} : {}", position, success);
 			// verify that the journal entry can be decoded
 			while (success && !foundInsert && rj.nextEntry()) {
-				EntryHeader eheader = rj.getEntryHeader();
+				final EntryHeader eheader = rj.getEntryHeader();
 				log.debug(eheader.toString());
-                JournalEntryType journalEntryType = eheader.getJournalEntryType();
-                System.out.println(journalEntryType);
-                if (journalEntryType == null)
-                    continue;
-				switch (journalEntryType) {
-    				case ADD_ROW2, ADD_ROW1:
-    					System.out.println(eheader.getObjectName() + " : " + eheader.getLibrary());
-    					if ("CCSID".equals(eheader.getFile()) && "MSTYPE1".equals(eheader.getLibrary())) {
-	    					Object[] values = rj.decode(fileDecoder);
-	    					AS400Text conv = new AS400Text(10, 37);
-	    					TableInfo ti = schemaHash.retrieve(database, schema, "CCSID");
-	    					System.out.println("found add for table " + eheader.getFile());
-	    					assertNotNull(ti);
-	    					List<Structure> structures = ti.getStructure();
-	    					Map<String, Object> map = toValues(structures, values);
-	    					assertEquals(SPECIAL_CHARACTERS, ((String)map.get("UK")).trim());
-	    					assertEquals(SPECIAL_CHARACTERS, ((String)map.get("US")).trim());
-	    
-	    					foundInsert = true;
-    					}
-    					break;
-					default:
-					    break;
+				final JournalEntryType journalEntryType = eheader.getJournalEntryType();
+				log.debug("journal entry {}", journalEntryType);
+				if (journalEntryType == null) {
+					continue;
 				}
-				JournalProcessedPosition next = rj.getPosition();
+				switch (journalEntryType) {
+				case ADD_ROW2, ADD_ROW1:
+					log.debug("add {}, {}", eheader.getObjectName(), eheader.getLibrary());
+				if ("CCSID".equals(eheader.getFile()) && "MSTYPE1".equals(eheader.getLibrary())) {
+					final Object[] values = rj.decode(fileDecoder);
+					final AS400Text conv = new AS400Text(10, 37);
+					final TableInfo ti = schemaHash.retrieve(database, schema, "CCSID");
+					assertNotNull(ti);
+					final List<Structure> structures = ti.getStructure();
+					final Map<String, Object> map = toValues(structures, values);
+					assertEquals(SPECIAL_CHARACTERS, ((String)map.get("UK")).trim());
+					assertEquals(SPECIAL_CHARACTERS, ((String)map.get("US")).trim());
+
+					foundInsert = true;
+				}
+				break;
+				default:
+					break;
+				}
+				final JournalProcessedPosition next = rj.getPosition();
 				if (position.equals(next)) {
 					Thread.sleep(100);
 				}
@@ -112,9 +112,9 @@ class JournalEntryCcsidIT {
 
 		assertEquals(true, foundInsert, "insert journal entry found");
 	}
-	
+
 	public static void setupSchemaAndTable() throws SQLException {
-		Connection con = sqlConnect.connection(); // debezium doesn't close connections
+		final Connection con = sqlConnect.connection(); // debezium doesn't close connections
 		try (Statement stmt = con.createStatement()) {
 			createSchema(stmt);
 			createEmptyTable(stmt);
@@ -127,7 +127,7 @@ class JournalEntryCcsidIT {
 		try (ResultSet rs = stmt
 				.executeQuery("select count(1) from qsys2.systables where table_schema='MSTYPE1'")) {
 			if (rs.next()) {
-				int found = rs.getInt(1);
+				final int found = rs.getInt(1);
 				if (found < 1) {
 					log.debug("create schema");
 					stmt.executeUpdate("create schema MSTYPE1");
@@ -135,29 +135,26 @@ class JournalEntryCcsidIT {
 			}
 		}
 	}
-	
+
 	private void insertData() throws SQLException {
-		Connection con = sqlConnect.connection(); // debezium doesn't close connections
+		final Connection con = sqlConnect.connection(); // debezium doesn't close connections
 		try (Statement stmt = con.createStatement()) {
 
 			// bin is ebidic a385a2a3 not ascii 74657374
-			int added = stmt.executeUpdate("INSERT INTO MSTYPE1.ccsid (uk, us) values ('£$[^~?¢', '£$[^~?¢')");
-			
+			final int added = stmt.executeUpdate("INSERT INTO MSTYPE1.ccsid (uk, us) values ('£$[^~?¢', '£$[^~?¢')");
+
 			assertEquals(1, added, "inserted one row");
 
 			// verify we can find the data using sql
 			try (ResultSet rs = stmt
 					.executeQuery("select uk, us from MSTYPE1.ccsid")) {
-				AS400Text ukconv = new AS400Text(10, 285);
-				AS400Text usconv = new AS400Text(10, 37);
+				final AS400Text ukconv = new AS400Text(10, 285);
+				final AS400Text usconv = new AS400Text(10, 37);
 				if (rs.next()) {
 					assertEquals(SPECIAL_CHARACTERS, rs.getString("uk").trim());
 					assertEquals(SPECIAL_CHARACTERS, rs.getString("us").trim());
 					assertArrayEquals(ukconv.toBytes(SPECIAL_CHARACTERS), rs.getBytes("uk"));
 					assertArrayEquals(usconv.toBytes(SPECIAL_CHARACTERS), rs.getBytes("us"));
-					
-					System.out.println(bytesToHex(rs.getBytes("uk")));
-					System.out.println(bytesToHex( rs.getBytes("us")));
 				} else {
 					fail("should find a result");
 				}
@@ -168,7 +165,7 @@ class JournalEntryCcsidIT {
 	private static void createEmptyTable(Statement stmt) throws SQLException {
 		try {
 			stmt.executeUpdate("drop TABLE MSTYPE1.ccsid");
-		} catch (SQLException e) {
+		} catch (final SQLException e) {
 			// ignore we don't care if it doesn't exist yet
 		}
 
@@ -177,21 +174,21 @@ class JournalEntryCcsidIT {
 
 		stmt.executeUpdate("delete from MSTYPE1.ccsid");
 	}
-	
+
 	private static final byte[] HEX_ARRAY = "0123456789ABCDEF".getBytes(StandardCharsets.US_ASCII);
 	public static String bytesToHex(byte[] bytes) {
-	    byte[] hexChars = new byte[bytes.length * 2];
-	    for (int j = 0; j < bytes.length; j++) {
-	        int v = bytes[j] & 0xFF;
-	        hexChars[j * 2] = HEX_ARRAY[v >>> 4];
-	        hexChars[j * 2 + 1] = HEX_ARRAY[v & 0x0F];
-	    }
-	    return new String(hexChars, StandardCharsets.UTF_8);
+		final byte[] hexChars = new byte[bytes.length * 2];
+		for (int j = 0; j < bytes.length; j++) {
+			final int v = bytes[j] & 0xFF;
+			hexChars[j * 2] = HEX_ARRAY[v >>> 4];
+			hexChars[j * 2 + 1] = HEX_ARRAY[v & 0x0F];
+		}
+		return new String(hexChars, StandardCharsets.UTF_8);
 	}
-	
+
 	public Map<String, Object> toValues(List<Structure> structures, Object[] values) {
-		Map<String, Object> map = new HashMap<>();
-		
+		final Map<String, Object> map = new HashMap<>();
+
 		for (int i=0; i< structures.size(); i++) {
 			map.put(structures.get(i).getName(), values[i]);
 		}

--- a/journal-parsing/src/it/java/com/fnz/db2/journal/retrieve/JournalEntryDecoderTestIT.java
+++ b/journal-parsing/src/it/java/com/fnz/db2/journal/retrieve/JournalEntryDecoderTestIT.java
@@ -32,81 +32,81 @@ import com.ibm.as400.access.AS400Text;
 // this file is utf-8
 
 class JournalEntryDecoderTestIT {
-    private static final Logger log = LoggerFactory.getLogger(JournalEntryDecoderTestIT.class);
+	private static final Logger log = LoggerFactory.getLogger(JournalEntryDecoderTestIT.class);
 
 	static Connect<AS400, IOException> as400Connect;
 	static Connect<Connection, SQLException> sqlConnect;
-	
+
 	static String schema = "MSTYPE1";
 
 	@BeforeAll
 	public static void setup() throws Exception {
-        TestConnector connector = new TestConnector();
-        as400Connect = connector.getAs400();
-        sqlConnect = connector.getJdbc();
-        
+		final TestConnector connector = new TestConnector();
+		as400Connect = connector.getAs400();
+		sqlConnect = connector.getJdbc();
+
 		setupSchema();
 	}
 
 	@Test
 	public void testCharacterTypes() throws Exception {
-		JournalInfoRetrieval journalInfoRetrieval = new JournalInfoRetrieval();
-		JournalInfo journal = JournalInfoRetrieval.getJournal(as400Connect.connection(), schema);
-		Instant now = Instant.now();
-		JournalPosition current = journalInfoRetrieval.getCurrentPosition(as400Connect.connection(), journal);
-		JournalProcessedPosition position = new JournalProcessedPosition(current, now, true);
-		System.out.println("starting at " + position);
+		final JournalInfoRetrieval journalInfoRetrieval = new JournalInfoRetrieval();
+		final JournalInfo journal = JournalInfoRetrieval.getJournal(as400Connect.connection(), schema);
+		final Instant now = Instant.now();
+		final JournalPosition current = journalInfoRetrieval.getCurrentPosition(as400Connect.connection(), journal);
+		final JournalProcessedPosition position = new JournalProcessedPosition(current, now, true);
+		log.debug("starting at {}", position);
 
 		insertData();
 
-		RetrieveConfig config = new RetrieveConfigBuilder().withAs400(as400Connect).withJournalInfo(journal).build();
-		RetrieveJournal rj = new RetrieveJournal(config, journalInfoRetrieval);
-		
-		SchemaCacheHash schemaHash = new SchemaCacheHash();
+		final RetrieveConfig config = new RetrieveConfigBuilder().withAs400(as400Connect).withJournalInfo(journal).build();
+		final RetrieveJournal rj = new RetrieveJournal(config, journalInfoRetrieval);
 
-        String database = JdbcFileDecoder.getDatabaseName(sqlConnect.connection());
-        JdbcFileDecoder fileDecoder = new JdbcFileDecoder(sqlConnect, database, schemaHash, -1);
+		final SchemaCacheHash schemaHash = new SchemaCacheHash();
+
+		final String database = JdbcFileDecoder.getDatabaseName(sqlConnect.connection());
+		final JdbcFileDecoder fileDecoder = new JdbcFileDecoder(sqlConnect, database, schemaHash, -1, -1);
 		boolean foundInsert = false;
 		boolean success = true;
-	
+
 		for (int i=0; success && !foundInsert && i < 100; i++) { // journal entries are not available straight away
 			success = rj.retrieveJournal(position);
-			System.out.println(position+ " : " + success);
+			log.info("position {} : {}", position, success);
 			// verify that the journal entry can be decoded
 			while (success && !foundInsert && rj.nextEntry()) {
-				EntryHeader eheader = rj.getEntryHeader();
-				log.debug(eheader.toString());
-                JournalEntryType journalEntryType = eheader.getJournalEntryType();
-                System.out.println(journalEntryType);
-                if (journalEntryType == null)
-                    continue;
-				switch (journalEntryType) {
-    				case ADD_ROW2, ADD_ROW1:
-    					System.out.println(eheader.getObjectName() + " : " + eheader.getLibrary());
-    					if ("CHARTYPES".equals(eheader.getFile()) && "MSTYPE1".equals(eheader.getLibrary())) {
-	    					Object[] values = rj.decode(fileDecoder);
-	    					AS400Text conv = new AS400Text(10, 37);
-	    					TableInfo ti = schemaHash.retrieve(database, schema, "CHARTYPES");
-	    					System.out.println("found add for table " + eheader.getFile());
-	    					assertNotNull(ti);
-	    					List<Structure> structures = ti.getStructure();
-	    					Map<String, Object> map = toValues(structures, values);
-	    					assertEquals("fixed", ((String)map.get("FCHAR")).trim());
-	    					assertEquals("var", ((String)map.get("VCHAR")).trim());
-	    //						assertThat(((String)map.get("FGRAPH")).trim(), is(equalTo("Paßstraße")));
-	    //						assertThat(((String)map.get("VGRAPH")).trim(), is(equalTo("Maſʒſtab")));
-	    					System.out.println(bytesToHex(conv.toBytes("abcdefghij")));
-	    					System.out.println(bytesToHex(((byte[])map.get("FBIN"))));
-	    					assertArrayEquals(conv.toBytes("abcdefghij"), ((byte[])map.get("FBIN")), "fixed binary");
-	    					assertArrayEquals(conv.toBytes("klnmopqrst"), ((byte[])map.get("VBIN")), "var binary");
-	    
-	    					foundInsert = true;
-    					}
-    					break;
-					default:
-					    break;
+				final EntryHeader eheader = rj.getEntryHeader();
+				log.info(eheader.toString());
+				final JournalEntryType journalEntryType = eheader.getJournalEntryType();
+				log.info("journal type {}", journalEntryType);
+				if (journalEntryType == null) {
+					continue;
 				}
-				JournalProcessedPosition next = rj.getPosition();
+				switch (journalEntryType) {
+				case ADD_ROW2, ADD_ROW1:
+					log.info("add row {} : {}", eheader.getObjectName(), eheader.getLibrary());
+				if ("CHARTYPES".equals(eheader.getFile()) && "MSTYPE1".equals(eheader.getLibrary())) {
+					final Object[] values = rj.decode(fileDecoder);
+					final AS400Text conv = new AS400Text(10, 37);
+					final TableInfo ti = schemaHash.retrieve(database, schema, "CHARTYPES");
+					assertNotNull(ti);
+					final List<Structure> structures = ti.getStructure();
+					final Map<String, Object> map = toValues(structures, values);
+					assertEquals("fixed", ((String)map.get("FCHAR")).trim());
+					assertEquals("var", ((String) map.get("VCHAR")).trim());
+					assertEquals("Paßstraße", ((String) map.get("FGRAPH")).trim());
+					assertEquals("Maſʒſtab", ((String) map.get("VGRAPH")).trim());
+					log.info(bytesToHex(conv.toBytes("abcdefghij")));
+					log.info(bytesToHex(((byte[]) map.get("FBIN"))));
+					assertArrayEquals(conv.toBytes("abcdefghij"), ((byte[])map.get("FBIN")), "fixed binary");
+					assertArrayEquals(conv.toBytes("klnmopqrst"), ((byte[])map.get("VBIN")), "var binary");
+
+					foundInsert = true;
+				}
+				break;
+				default:
+					break;
+				}
+				final JournalProcessedPosition next = rj.getPosition();
 				if (position.equals(next)) {
 					Thread.sleep(100);
 				}
@@ -118,31 +118,34 @@ class JournalEntryDecoderTestIT {
 	}
 
 	private void insertData() throws SQLException {
-		Connection con = sqlConnect.connection(); // debezium doesn't close connections
+		final Connection con = sqlConnect.connection(); // debezium doesn't close connections
 		try (Statement stmt = con.createStatement()) {
 
 
 			// bin is ebidic a385a2a3 not ascii 74657374
-			int added = stmt.executeUpdate("INSERT INTO MSTYPE1.CHARTYPES (fchar, vchar, "
-//					+ "fgraph, vgraph, "
+			final int added = stmt.executeUpdate("INSERT INTO MSTYPE1.CHARTYPES (fchar, vchar, "
+					+ "fgraph, "
+					+ " vgraph, "
 					+ "fbin, vbin) "
 					+ "VALUES ('fixed', 'var',"
-//					+ " 'Paßstraße', 'Maſʒſtab', "
+					+ " 'Paßstraße', "
+					+ "'Maſʒſtab', "
 					+ "CAST('abcdefghij' AS BINARY(10)) , CAST('klnmopqrst' AS VARBINARY(10)))");
-			
+
 			assertEquals(1, added, "inserted one row");
 
 			// verify we can find the data using sql
 			try (ResultSet rs = stmt
-					.executeQuery("select fchar, vchar, "
-//							+ "fgraph, vgraph, "
-							+ "fbin, vbin from MSTYPE1.CHARTYPES")) {
-				AS400Text conv = new AS400Text(10, 37);
+					.executeQuery("""
+							select fchar, vchar, fgraph,"""
+									+ "vgraph,"
+									+ "fbin, vbin from MSTYPE1.CHARTYPES")) {
+				final AS400Text conv = new AS400Text(10, 37);
 				if (rs.next()) {
 					assertEquals("fixed", rs.getString("fchar").trim());
 					assertEquals("var", rs.getString("vchar").trim());
-//					assertThat(rs.getString("fgraph").trim(), is(equalTo("Paßstraße")));
-//					assertThat(rs.getString("vgraph").trim(), is(equalTo("Maſʒſtab")));
+					assertEquals("Paßstraße", rs.getString("fgraph").trim());
+					assertEquals("Maſʒſtab", rs.getString("vgraph").trim());
 					assertArrayEquals(conv.toBytes("abcdefghij"), rs.getBytes("fbin"));
 					assertArrayEquals(conv.toBytes("klnmopqrst"), rs.getBytes("vbin"));
 				} else {
@@ -153,7 +156,7 @@ class JournalEntryDecoderTestIT {
 	}
 
 	private static void setupSchema() throws SQLException {
-		Connection con = sqlConnect.connection(); // debezium doesn't close connections
+		final Connection con = sqlConnect.connection(); // debezium doesn't close connections
 		try (Statement stmt = con.createStatement()) {
 			createSchema(stmt);
 			createEmptyTable(stmt);
@@ -164,7 +167,7 @@ class JournalEntryDecoderTestIT {
 		try (ResultSet rs = stmt
 				.executeQuery("select count(1) from qsys2.systables where table_schema='MSTYPE1'")) {
 			if (rs.next()) {
-				int found = rs.getInt(1);
+				final int found = rs.getInt(1);
 				if (found < 1) {
 					log.debug("create schema");
 					stmt.executeUpdate("create schema MSTYPE1");
@@ -177,32 +180,35 @@ class JournalEntryDecoderTestIT {
 	private static void createEmptyTable(Statement stmt) throws SQLException {
 		try {
 			stmt.executeUpdate("drop TABLE MSTYPE1.CHARTYPES");
-		} catch (SQLException e) {
+		} catch (final SQLException e) {
+			e.printStackTrace();
 			// ignore we don't care if it doesn't exist yet
 		}
 
-		stmt.executeUpdate(
-				"CREATE OR replace TABLE MSTYPE1.CHARTYPES (  " + "fchar CHAR(12), vchar VARCHAR(11),    "
-//							+ "fgraph GRAPHIC(10) CCSID 13488,  vgraph VARGRAPHIC(10) CCSID 13488,  "
-						+ "fbin binary(10),  vbin varbinary(10)  )");
+		stmt.executeUpdate("""
+				CREATE TABLE MSTYPE1.CHARTYPES (
+						fchar CHAR(12), vchar VARCHAR(11),
+						fgraph GRAPHIC(10) CCSID 13488,  """
+								+ "vgraph VARGRAPHIC(10) CCSID 13488,"
+								+ " fbin binary(10),  vbin varbinary(10)  )");
 
-		stmt.executeUpdate("delete from MSTYPE1.CHARTYPES");
+				stmt.executeUpdate("delete from MSTYPE1.CHARTYPES");
 	}
-	
+
 	private static final byte[] HEX_ARRAY = "0123456789ABCDEF".getBytes(StandardCharsets.US_ASCII);
 	public static String bytesToHex(byte[] bytes) {
-	    byte[] hexChars = new byte[bytes.length * 2];
-	    for (int j = 0; j < bytes.length; j++) {
-	        int v = bytes[j] & 0xFF;
-	        hexChars[j * 2] = HEX_ARRAY[v >>> 4];
-	        hexChars[j * 2 + 1] = HEX_ARRAY[v & 0x0F];
-	    }
-	    return new String(hexChars, StandardCharsets.UTF_8);
+		final byte[] hexChars = new byte[bytes.length * 2];
+		for (int j = 0; j < bytes.length; j++) {
+			final int v = bytes[j] & 0xFF;
+			hexChars[j * 2] = HEX_ARRAY[v >>> 4];
+			hexChars[j * 2 + 1] = HEX_ARRAY[v & 0x0F];
+		}
+		return new String(hexChars, StandardCharsets.UTF_8);
 	}
-	
+
 	public Map<String, Object> toValues(List<Structure> structures, Object[] values) {
-		Map<String, Object> map = new HashMap<>();
-		
+		final Map<String, Object> map = new HashMap<>();
+
 		for (int i=0; i< structures.size(); i++) {
 			map.put(structures.get(i).getName(), values[i]);
 		}

--- a/journal-parsing/src/main/java/com/fnz/db2/journal/data/types/AS400VarChar.java
+++ b/journal-parsing/src/main/java/com/fnz/db2/journal/data/types/AS400VarChar.java
@@ -1,6 +1,7 @@
 package com.fnz.db2.journal.data.types;
 
 import com.ibm.as400.access.AS400Bin2;
+import com.ibm.as400.access.AS400Bin4;
 import com.ibm.as400.access.AS400DataType;
 import com.ibm.as400.access.AS400Text;
 import com.ibm.as400.access.InternalErrorException;
@@ -8,21 +9,25 @@ import com.ibm.as400.access.Trace;
 
 public class AS400VarChar implements AS400DataType {
 	private static final AS400Bin2 AS400_BIN2 = new AS400Bin2();
-    private final int maxLenght;
+	private static final AS400Bin4 AS400_BIN4 = new AS400Bin4();
+	private final int maxLenght;
 	private final static String defaultValue = "";
 	private int actualLength;
 	private final int ccsid;
+	private final int bytesPerChar;
 
-	public AS400VarChar(int maxLenght) {
-		this.maxLenght = maxLenght;
+	public AS400VarChar(int maxLenght, int bytesPerChar) {
+		this.maxLenght = maxLenght * bytesPerChar;
+		this.bytesPerChar = bytesPerChar;
 		ccsid = -1;
 	}
 
-	public AS400VarChar(int maxLenght, int ccsid) {
-		this.maxLenght = maxLenght;
+	public AS400VarChar(int maxLenght, int bytesPerChar, int ccsid) {
 		this.ccsid = ccsid;
+		this.bytesPerChar = bytesPerChar;
+		this.maxLenght = maxLenght * bytesPerChar;
 	}
-	
+
 	@Override
 	public int getByteLength() {
 		return maxLenght + 2;
@@ -65,23 +70,25 @@ public class AS400VarChar implements AS400DataType {
 
 	@Override
 	public Object toObject(byte[] data, int offset) {
+		final int lenOffset = 2;
 		actualLength = (Short)AS400_BIN2.toObject(data, offset);
-		AS400Text txt = (ccsid > 0) ? new AS400Text(actualLength, ccsid) : new AS400Text(actualLength);
-		String text = (String)txt.toObject(data, offset + 2);
+		actualLength *= bytesPerChar;
+		final AS400Text txt = (ccsid > 0) ? new AS400Text(actualLength, ccsid) : new AS400Text(actualLength);
+		final String text = (String) txt.toObject(data, offset + lenOffset);
 		return text;
 	}
 
 	@Override
 	public Object clone() {
-        try
-        {
-            return super.clone();  // Object.clone does not throw exception.
-        }
-        catch (CloneNotSupportedException e)
-        {
-            Trace.log(Trace.ERROR, "Unexpected CloneNotSupportedException:", e);
-            throw new InternalErrorException(InternalErrorException.UNEXPECTED_EXCEPTION);
-        }
+		try
+		{
+			return super.clone();  // Object.clone does not throw exception.
+		}
+		catch (final CloneNotSupportedException e)
+		{
+			Trace.log(Trace.ERROR, "Unexpected CloneNotSupportedException:", e);
+			throw new InternalErrorException(InternalErrorException.UNEXPECTED_EXCEPTION);
+		}
 	}
 
 }

--- a/journal-parsing/src/main/java/com/fnz/db2/journal/data/types/AS400VarChar.java
+++ b/journal-parsing/src/main/java/com/fnz/db2/journal/data/types/AS400VarChar.java
@@ -14,6 +14,23 @@ public class AS400VarChar implements AS400DataType {
 	private final static String defaultValue = "";
 	private int actualLength;
 	private final int ccsid;
+	/*
+	 * as400 correctly decodes the charset but relies on the length being the buffer
+	 * length not the number of characters.
+	 *
+	 * The length in the system catalogue is the number of characters.
+	 *
+	 * The character_octet_length seems to represent the buffer length.
+	 *
+	 * For a var char the length is encoded in the first two bytes of the buffer and
+	 * again this is the number of characters not the buffer length.
+	 *
+	 * So we need the bytesPerChar multiplier to calculate the buffer size or we'd
+	 * need to resolve the number of characters for the ccsid
+	 *
+	 * PRG reference
+	 * https://www.ibm.com/docs/en/i/7.5?topic=type-graphic-format#dgraph
+	 */
 	private final int bytesPerChar;
 
 	public AS400VarChar(int maxLenght, int bytesPerChar) {

--- a/journal-parsing/src/main/java/com/fnz/db2/journal/retrieve/BytesPerChar.java
+++ b/journal-parsing/src/main/java/com/fnz/db2/journal/retrieve/BytesPerChar.java
@@ -1,0 +1,68 @@
+package com.fnz.db2.journal.retrieve;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BytesPerChar {
+	private static final String GET_OCTET_LENGTH = "select table_name, system_table_name, column_name, system_column_name, length, character_octet_length FROM qsys2.SYSCOLUMNS where table_schema=? and (system_table_name = ? or table_name = ?)";
+	private final Map<String, Integer> octetLenghtMap = new HashMap<>();
+	private final Connect<Connection, SQLException> jdbcConnect;
+	static final Logger log = LoggerFactory.getLogger(BytesPerChar.class);
+
+	public BytesPerChar(final Connect<Connection, SQLException> jdbcConnect) {
+		this.jdbcConnect = jdbcConnect;
+	}
+
+	public Integer getBytesPerChar(String schema, String table, String columnName) {
+		final String canonicalName = String.format("%s.%s.%s", schema, table, columnName);
+		if (octetLenghtMap.containsKey(canonicalName)) {
+			return octetLenghtMap.get(canonicalName);
+		}
+
+		try {
+			fetchAllOctetLengthForTable(schema, table);
+
+			return octetLenghtMap.get(canonicalName);
+		} catch (final SQLException e) {
+			log.error("failed to fetch octet length", e);
+			return -1;
+		}
+	}
+
+	private void fetchAllOctetLengthForTable(String schema, String table) throws SQLException {
+		final Connection con = jdbcConnect.connection();
+		try (PreparedStatement ps = con.prepareStatement(GET_OCTET_LENGTH)) {
+			ps.setString(1, schema.toUpperCase());
+			ps.setString(2, table.toUpperCase());
+			ps.setString(3, table.toUpperCase());
+			try (ResultSet rs = ps.executeQuery()) {
+				while (rs.next()) {
+					final String longTableName = StringHelpers.safeTrim(rs.getString(1));
+					final String shortTableName = StringHelpers.safeTrim(rs.getString(2));
+					final String longcolumn = StringHelpers.safeTrim(rs.getString(3));
+					final String shortcolumn = StringHelpers.safeTrim(rs.getString(4));
+					final int length = rs.getInt(5);
+					final int octetLength = rs.getInt(6);
+					add(schema, longTableName, longcolumn, length, octetLength);
+					add(schema, shortTableName, shortcolumn, length, octetLength);
+				}
+			}
+		}
+	}
+
+	public void add(String schema, String table, String column, int length, int octetLength) {
+		final String canonicalLongName = String.format("%s.%s.%s", schema, table, column);
+		int bytesPerChar = octetLength / length;
+		bytesPerChar = (bytesPerChar < 1) ? 1 : bytesPerChar;
+		log.debug("bytes per char {} {} {} {}", schema, table, column, bytesPerChar);
+		octetLenghtMap.put(canonicalLongName, bytesPerChar);
+	}
+
+}

--- a/journal-parsing/src/main/java/com/fnz/db2/journal/retrieve/BytesPerChar.java
+++ b/journal-parsing/src/main/java/com/fnz/db2/journal/retrieve/BytesPerChar.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class BytesPerChar {
+	/* @See com.fnz.db2.journal.data.types.AS400VarChar */
 	private static final String GET_OCTET_LENGTH = "select table_name, system_table_name, column_name, system_column_name, length, character_octet_length FROM qsys2.SYSCOLUMNS where table_schema=? and (system_table_name = ? or table_name = ?)";
 	private final Map<String, Integer> octetLenghtMap = new HashMap<>();
 	private final Connect<Connection, SQLException> jdbcConnect;

--- a/journal-parsing/src/main/java/com/fnz/db2/journal/retrieve/CcsidCache.java
+++ b/journal-parsing/src/main/java/com/fnz/db2/journal/retrieve/CcsidCache.java
@@ -1,0 +1,73 @@
+package com.fnz.db2.journal.retrieve;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CcsidCache {
+	private static final String GET_CCSID = "select table_name, system_table_name, column_name, system_column_name, ccsid FROM qsys2.SYSCOLUMNS where table_schema=? and (system_table_name = ? or table_name = ?)";
+	private final Map<String, Integer> ccsidMap = new HashMap<>();
+	private final Connect<Connection, SQLException> jdbcConnect;
+	static final Logger log = LoggerFactory.getLogger(CcsidCache.class);
+	private final int fromCcsid;
+	private final int toCcsid;
+
+
+	public CcsidCache(final Connect<Connection, SQLException> jdbcConnect, Integer fromCcsid, Integer toCcsid) {
+		this.jdbcConnect = jdbcConnect;
+		this.fromCcsid = (fromCcsid == null) ? -1 : fromCcsid;
+		this.toCcsid = (toCcsid == null) ? -1 : toCcsid;
+
+	}
+
+	public Integer getCcsid(String schema, String table, String columnName) {
+		final String canonicalName = String.format("%s.%s.%s", schema, table, columnName);
+		if (ccsidMap.containsKey(canonicalName)) {
+			return ccsidMap.get(canonicalName);
+		}
+
+		try {
+			fetchAllCcsidForTable(schema, table);
+
+			return ccsidMap.get(canonicalName);
+		} catch (final SQLException e) {
+			log.error("failed to fetch ccsid", e);
+			return -1;
+		}
+	}
+
+	private void fetchAllCcsidForTable(String schema, String table) throws SQLException {
+		final Connection con = jdbcConnect.connection();
+		try (PreparedStatement ps = con.prepareStatement(GET_CCSID)) {
+			ps.setString(1, schema.toUpperCase());
+			ps.setString(2, table.toUpperCase());
+			ps.setString(3, table.toUpperCase());
+			try (ResultSet rs = ps.executeQuery()) {
+				while (rs.next()) {
+					final String longTableName = StringHelpers.safeTrim(rs.getString(1));
+					final String shortTableName = StringHelpers.safeTrim(rs.getString(2));
+					final String longcolumn = StringHelpers.safeTrim(rs.getString(3));
+					final String shortcolumn = StringHelpers.safeTrim(rs.getString(4));
+					final Object ccsidObj = rs.getObject(5);
+					final String canonicalLongName = String.format("%s.%s.%s", schema, longTableName, longcolumn);
+					final String canonicalShortName = String.format("%s.%s.%s", schema, shortTableName, shortcolumn);
+					int ccsid = (ccsidObj == null) ? -1 : (Integer) ccsidObj;
+
+					if (fromCcsid == ccsid && toCcsid != -1) {
+						log.debug("overriding ccsid for {} was {} now {}", longTableName, fromCcsid, toCcsid);
+						ccsid = toCcsid;
+					}
+					ccsidMap.put(canonicalLongName, ccsid);
+					ccsidMap.put(canonicalShortName, ccsid);
+				}
+			}
+		}
+	}
+
+}

--- a/journal-parsing/src/main/java/com/fnz/db2/journal/retrieve/RetrieveConfigBuilder.java
+++ b/journal-parsing/src/main/java/com/fnz/db2/journal/retrieve/RetrieveConfigBuilder.java
@@ -13,8 +13,8 @@ import com.ibm.as400.access.AS400;
 
 public class RetrieveConfigBuilder {
 
-    private static final Logger log = LoggerFactory.getLogger(RetrieveConfigBuilder.class);
-	
+	private static final Logger log = LoggerFactory.getLogger(RetrieveConfigBuilder.class);
+
 	private Connect<AS400, IOException> as400;
 	private JournalInfo journalInfo;
 	private File dumpFolder;
@@ -38,14 +38,14 @@ public class RetrieveConfigBuilder {
 	}
 
 	public RetrieveConfigBuilder withDumpFolder(String dumpFolder) {
-		if (dumpFolder != null) {
-			File f = new File(dumpFolder);
+		if (dumpFolder != null && !dumpFolder.isBlank()) {
+			final File f = new File(dumpFolder);
 			if (f.exists()) {
 				this.dumpFolder = f;
 				return this;
 			}
 		}
-        log.error("ignoring dump folder {} as it doesn't exist", dumpFolder);
+		log.error("ignoring dump folder {} as it doesn't exist", dumpFolder);
 		return this;
 	}
 
@@ -62,7 +62,7 @@ public class RetrieveConfigBuilder {
 		}
 		return this;
 	}
-	
+
 	public RetrieveConfigBuilder withServerFiltering(boolean filtering) {
 		this.filtering = filtering;
 		return this;
@@ -70,14 +70,14 @@ public class RetrieveConfigBuilder {
 
 	public RetrieveConfigBuilder withIncludeFiles(List<FileFilter> includeFiles) {
 		if (includeFiles != null) {
-		    if (includeFiles.size() < 300) {
-		        this.includeFiles = includeFiles;
-		    } else {
-		        log.error("ignoring filter list as too many files included {} limit 300", includeFiles.size());
-		        this.includeFiles = Collections.<FileFilter>emptyList();
-		    }
+			if (includeFiles.size() < 300) {
+				this.includeFiles = includeFiles;
+			} else {
+				log.error("ignoring filter list as too many files included {} limit 300", includeFiles.size());
+				this.includeFiles = Collections.<FileFilter>emptyList();
+			}
 		} else {
-            this.includeFiles = Collections.<FileFilter>emptyList();
+			this.includeFiles = Collections.<FileFilter>emptyList();
 		}
 
 		return this;

--- a/journal-parsing/src/main/java/com/fnz/db2/journal/retrieve/SchemaCacheIF.java
+++ b/journal-parsing/src/main/java/com/fnz/db2/journal/retrieve/SchemaCacheIF.java
@@ -9,18 +9,18 @@ public interface SchemaCacheIF {
 	void store(String database, String schema, String table, TableInfo tableInfo);
 	TableInfo retrieve(String database, String schema, String table);
 	void clearCache(String database, String schema, String table);
-	
+
 	public class TableInfo {
 		private final List<Structure> structure;
 		private final AS400Structure as400Structure;
-//		private final AS400Structure as400Keys;
+		//		private final AS400Structure as400Keys;
 		private final List<String> primaryKeys;
 
 		public TableInfo(List<Structure> structure, List<String> primaryKeys, AS400Structure as400Structure) {
 			super();
 			this.structure = structure;
 			this.as400Structure = as400Structure;
-//			this.as400Keys = as400Keys;
+			//			this.as400Keys = as400Keys;
 			this.primaryKeys = primaryKeys;
 		}
 		public List<Structure> getStructure() {
@@ -35,15 +35,16 @@ public interface SchemaCacheIF {
 		@Override
 		public String toString() {
 			return "TableInfo [ primaryKeys=" + toString(primaryKeys) + " structure=[" + toString(structure) + "] ]";
-		}		
-		
+		}
+
 		public String toString(List<? extends Object> l) {
-			if (l == null)
+			if (l == null) {
 				return "";
+			}
 			return l.stream().map(Object::toString).collect(Collectors.joining(","));
 		}
 	}
-	
+
 	public static class Structure {
 		private final String name;
 		private final String type;
@@ -54,8 +55,9 @@ public interface SchemaCacheIF {
 		private final int position;
 		private final boolean autoinc;
 		private final int ccsid;
-		
-		public Structure(String name, String type, int jdcbType, int length, int precision, boolean optional,
+
+		public Structure(String name, String type, int jdcbType, int length, int precision,
+				boolean optional,
 				int position, boolean autoinc) {
 			super();
 			this.name = name;

--- a/journal-parsing/src/main/java/com/fnz/db2/journal/test/CcsidDiscovery.java
+++ b/journal-parsing/src/main/java/com/fnz/db2/journal/test/CcsidDiscovery.java
@@ -14,30 +14,30 @@ import com.fnz.db2.journal.retrieve.SchemaCacheIF.TableInfo;
 
 public class CcsidDiscovery {
 	private static Logger log = LoggerFactory.getLogger(CcsidDiscovery.class);
-	
+
 	static TestConnector connector;
 	static Connect<Connection, SQLException> sqlConnect;
 	static String database;
-	
+
 	static String table;
 
 	public static void main(String[] args) throws Exception {
 		log.info("new");
-        connector = new TestConnector();
-        sqlConnect = connector.getJdbc();
-        table =  System.getenv("TABLE");
-        database = JdbcFileDecoder.getDatabaseName(sqlConnect.connection());
-        testToDataType();
+		connector = new TestConnector();
+		sqlConnect = connector.getJdbc();
+		table =  System.getenv("TABLE");
+		database = JdbcFileDecoder.getDatabaseName(sqlConnect.connection());
+		testToDataType();
 	}
 
 
 
 	public static void testToDataType() throws Exception {
-		JdbcFileDecoder decoder = new JdbcFileDecoder(sqlConnect, database, new SchemaCacheHash(), -1);
-		Optional<TableInfo> info = decoder.getRecordFormat(table, connector.getSchema());
+		final JdbcFileDecoder decoder = new JdbcFileDecoder(sqlConnect, database, new SchemaCacheHash(), -1, -1);
+		final Optional<TableInfo> info = decoder.getRecordFormat(table, connector.getSchema());
 
 		log.info("table info {}", info.get());
 		log.info("primary key {}", info.get().getPrimaryKeys());
 	}
-	
+
 }

--- a/journal-parsing/src/main/java/com/fnz/db2/journal/test/CommitLogProcessor.java
+++ b/journal-parsing/src/main/java/com/fnz/db2/journal/test/CommitLogProcessor.java
@@ -65,7 +65,7 @@ public class CommitLogProcessor {
 		}
 
 		final String database = JdbcFileDecoder.getDatabaseName(sqlConnect.connection());
-		fileDecoder = new JdbcFileDecoder(sqlConnect, database, schemaCache, -1);
+		fileDecoder = new JdbcFileDecoder(sqlConnect, database, schemaCache, -1, -1);
 		JournalProcessedPosition lastPosition = null;
 
 		final JournalPosition endPosition = journalInfoRetrieval.getCurrentPosition(as400Connect.connection(), journal);

--- a/journal-parsing/src/test/java/com/fnz/db2/journal/retrieve/CcsidDiscovery.java
+++ b/journal-parsing/src/test/java/com/fnz/db2/journal/retrieve/CcsidDiscovery.java
@@ -1,15 +1,8 @@
 package com.fnz.db2.journal.retrieve;
 
-
-
-
 import java.sql.Connection;
-import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.List;
 import java.util.Optional;
-
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,28 +12,28 @@ import com.fnz.db2.journal.test.TestConnector;
 
 public class CcsidDiscovery {
 
+	private static final Logger log = LoggerFactory.getLogger(CcsidDiscovery.class);
+
 	static TestConnector connector;
 	static Connect<Connection, SQLException> sqlConnect;
 	static String database;
-	
+
 	static String table;
 
 	public static void main(String[] args) throws Exception {
-        connector = new TestConnector();
-        sqlConnect = connector.getJdbc();
-        table =  System.getenv("TABLE");
-        database = JdbcFileDecoder.getDatabaseName(sqlConnect.connection());
-        testToDataType();
+		connector = new TestConnector();
+		sqlConnect = connector.getJdbc();
+		table =  System.getenv("TABLE");
+		database = JdbcFileDecoder.getDatabaseName(sqlConnect.connection());
+		testToDataType();
 	}
-
-
 
 	public static void testToDataType() throws Exception {
-		JdbcFileDecoder decoder = new JdbcFileDecoder(sqlConnect, database, new SchemaCacheHash(), -1);
-		Optional<TableInfo> info = decoder.getRecordFormat(table, connector.getSchema());
+		final JdbcFileDecoder decoder = new JdbcFileDecoder(sqlConnect, database, new SchemaCacheHash(), -1, -1);
+		final Optional<TableInfo> info = decoder.getRecordFormat(table, connector.getSchema());
 
-		System.out.println(info.get());
-		System.out.println(info.get().getPrimaryKeys());
+		log.info("{}", info.get());
+		log.info("{}", info.get().getPrimaryKeys());
 	}
-	
+
 }

--- a/journal-parsing/src/test/java/com/fnz/db2/journal/retrieve/JdbcFileDecoderTest.java
+++ b/journal-parsing/src/test/java/com/fnz/db2/journal/retrieve/JdbcFileDecoderTest.java
@@ -8,18 +8,22 @@ import com.ibm.as400.access.AS400DataType;
 
 public class JdbcFileDecoderTest {
 
-
 	@Test
 	public void testToDataType() throws Exception {
-		JdbcFileDecoder decoder = new JdbcFileDecoder(null, null, new SchemaCacheHash(), -1);;
-		AS400DataType passwordNoLength = decoder.toDataType("schem", "table", "password", "CHAR () FOR BIT DATA", 10, 0);
+		final JdbcFileDecoder decoder = new JdbcFileDecoder(null, null, new SchemaCacheHash(), -1, -1);
+		;
+		final AS400DataType passwordNoLength = decoder.toDataType("schem", "table", "password", "CHAR () FOR BIT DATA",
+				10, 0);
 		assertEquals(AS400DataType.TYPE_BYTE_ARRAY, passwordNoLength.getInstanceType());
-		AS400DataType passwordLength = decoder.toDataType("schem", "table", "password", "CHAR (20) FOR BIT DATA", 10, 0);
+		final AS400DataType passwordLength = decoder.toDataType("schem", "table", "password", "CHAR (20) FOR BIT DATA",
+				10, 0);
 		assertEquals(AS400DataType.TYPE_BYTE_ARRAY, passwordLength.getInstanceType());
 		assertEquals(20, passwordLength.getByteLength());
-		AS400DataType varPasswordNoLength = decoder.toDataType("schem", "table", "password", "VARCHAR () FOR BIT DATA", 10, 0);
+		final AS400DataType varPasswordNoLength = decoder.toDataType("schem", "table", "password",
+				"VARCHAR () FOR BIT DATA", 10, 0);
 		assertEquals(-1, varPasswordNoLength.getInstanceType());
-		AS400DataType varPasswordLength = decoder.toDataType("schem", "table", "password", "VARCHAR (20) FOR BIT DATA", 10, 0);
+		final AS400DataType varPasswordLength = decoder.toDataType("schem", "table", "password",
+				"VARCHAR (20) FOR BIT DATA", 10, 0);
 		assertEquals(-1, varPasswordLength.getInstanceType());
 		assertEquals(20, passwordLength.getByteLength());
 	}

--- a/jt400-override-ccsid/src/it/java/com/ibm/as400/access/CcsidOverrideTest.java
+++ b/jt400-override-ccsid/src/it/java/com/ibm/as400/access/CcsidOverrideTest.java
@@ -16,6 +16,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Properties;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.junit.jupiter.api.AfterAll;
@@ -51,10 +52,10 @@ public class CcsidOverrideTest {
 					final byte[] retrievedBytes = rs.getBytes(1); // retrieves unencoded
 					final byte[] expectedBytes = data.getBytes(wrongCcsidCP);
 
-					System.out.println(String.format("sent     %s", data));
-					System.out.println(String.format("received %s\n", retrieved));
-					System.out.println(String.format("expected ebdic  %s", bytesToHex(expectedBytes)));
-					System.out.println(String.format("recieved ebdic  %s", bytesToHex(retrievedBytes)));
+					log.log(Level.FINE, "sent     {0}", data);
+					log.log(Level.FINE, "received {0}", retrieved);
+					log.log(Level.FINE, "expected ebdic  {0}", bytesToHex(expectedBytes));
+					log.log(Level.FINE, "recieved ebdic  {0}", bytesToHex(retrievedBytes));
 
 					assertEquals(data, retrieved);
 					assertArrayEquals(expectedBytes, retrievedBytes);
@@ -85,11 +86,11 @@ public class CcsidOverrideTest {
 					final byte[] expectedBytes = data.getBytes(wrongCcsidCP);
 					final String expectedString = new String(expectedBytes, columnCcsidCP);
 
-					System.out.println(String.format("sent     %s", data));
-					System.out.println(String.format("received %s", retrieved));
-					System.out.println(String.format("expected %s\n", expectedString));
-					System.out.println(String.format("expected ebdic  %s", bytesToHex(expectedBytes)));
-					System.out.println(String.format("recieved ebdic  %s", bytesToHex(retrievedBytes)));
+					log.log(Level.FINE, "sent     {0}", data);
+					log.log(Level.FINE, "received {0}", retrieved);
+					log.log(Level.FINE, "expected {0}", expectedString);
+					log.log(Level.FINE, "expected ebdic  {0}", bytesToHex(expectedBytes));
+					log.log(Level.FINE, "recieved ebdic  {0}", bytesToHex(retrievedBytes));
 
 					assertEquals(expectedString, retrieved);
 					assertArrayEquals(expectedBytes, retrievedBytes);
@@ -100,7 +101,7 @@ public class CcsidOverrideTest {
 	}
 
 	private static void insertData(Connection con, String schema) throws SQLException {
-		System.out.println(con.getClass().toString());
+		log.info(con.getClass().toString());
 		try (PreparedStatement ps = con
 				.prepareStatement(String.format("insert into %s.ccsidTest (id, name) values (?, ?)", schema))) {
 			ps.setInt(1, 1);
@@ -150,9 +151,9 @@ public class CcsidOverrideTest {
 	@AfterAll
 	public static void cleanUp() throws SQLException {
 		AS400JDBCDriverRegistration.registerCcsidDriver();
-		Properties props = configurePropertiesForDriver(columnCcsid, wrongCcsid);
-        String host =  System.getenv("ISERIES_HOST");
-        String schema =  System.getenv("ISERIES_SCHEMA");
+		final Properties props = configurePropertiesForDriver(columnCcsid, wrongCcsid);
+		final String host =  System.getenv("ISERIES_HOST");
+		final String schema =  System.getenv("ISERIES_SCHEMA");
 
 		try (Connection con = DriverManager.getConnection(String.format("jdbc:as400://%s/", host), props)) {
 			dropTable(con, host, schema);


### PR DESCRIPTION
This fixes support for graphic and vargraphic types - ucs-2 or utf-16 character types

We use the fact the character_octet_length is a multiple of the length to work out how many bytes per character. In theory db2 supports 2 and 4 bytes but from the docs I've seen the ibmi only mentions 2 bytes

It would be realy useul if debezium captured the character_octet_length in their structure object this is readily avaiable in the jdbc columnMetadata parameter 16
https://docs.oracle.com/en/java/javase/11/docs/api/java.sql/java/sql/DatabaseMetaData.html#getColumns(java.lang.String,java.lang.String,java.lang.String,java.lang.String)
