### PR TITLE
old connector that wasn't required still referenced and prevents startup

### DIFF
--- a/debezium-connector-ibmi/src/main/resources/META-INF/services/org.apache.kafka.connect.source.SourceConnector
+++ b/debezium-connector-ibmi/src/main/resources/META-INF/services/org.apache.kafka.connect.source.SourceConnector
@@ -1,2 +1,1 @@
-io.debezium.connector.db2as400.As400JdbcConnector
 io.debezium.connector.db2as400.As400RpcConnector


### PR DESCRIPTION
there was a reference to a dummy class that has been removed and it prevents startup