### PR TITLE
DBZ-7959 Add fallback logic for diverging primary key columns

### DIFF
--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400JdbcConnection.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400JdbcConnection.java
@@ -5,7 +5,10 @@
  */
 package io.debezium.connector.db2as400;
 
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -163,7 +166,7 @@ public class As400JdbcConnection extends JdbcConnection implements Connect<Conne
         }
         if (pkColumnNames.isEmpty()) {
             pkColumnNames = readTableUniqueIndices(metadata, id);
-            if (!pkColumnNames.isEmpty()){
+            if (!pkColumnNames.isEmpty()) {
                 pkColumnNames = mapSystemColumnNamesToLongNames(id, pkColumnNames);
             }
         }


### PR DESCRIPTION
There can be cases that we encountered, where there is a divergence between visible and system column names. In this case the connector would fail because it is unable to discover the correct primary key. I've added a fallback method where it maps system columns to visible column names to fix this issue.