### PR TITLE
DBZ-8131 prevent connector from crashing when running in schema_only mode

### DIFF
--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorTask.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorTask.java
@@ -91,12 +91,14 @@ public class As400ConnectorTask extends BaseSourceTask<As400Partition, As400Offs
 
         final ErrorHandler errorHandler = new ErrorHandler(As400RpcConnector.class, connectorConfig, queue, null);
 
-        final Offsets<As400Partition, As400OffsetContext> previousOffsetPartition = getPreviousOffsets(
+        Offsets<As400Partition, As400OffsetContext> previousOffsetPartition = getPreviousOffsets(
                 new As400Partition.Provider(connectorConfig), new As400OffsetContext.Loader(connectorConfig));
         As400OffsetContext previousOffset = previousOffsetPartition.getTheOnlyOffset();
         if (previousOffset == null) {
             LOGGER.info("previous offsets not found creating from config");
             previousOffset = new As400OffsetContext(connectorConfig);
+            previousOffsetPartition = Offsets.of(new As400Partition(connectorConfig.getHostname()),
+                    previousOffset);
         }
 
         final SnapshotterService snapshotterService = connectorConfig.getServiceRegistry().tryGetService(SnapshotterService.class);


### PR DESCRIPTION
Added a new Offset for previousOffsetPartition in order to prevent the connector from crashing when schema_only config is used. While this will still cause a nullpointer exception to be thrown on the first call of  getOffset() in AS400OffsetContext after snapshotting the table schemas, it does not seem to cause any problems with the connector.