### PR TITLE
DBZ-8129 ibmi Connector does not take custom properties into account anymore

### DIFF
--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400RpcConnection.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400RpcConnection.java
@@ -50,7 +50,7 @@ public class As400RpcConnection implements AutoCloseable, Connect<AS400, IOExcep
     public As400RpcConnection(As400ConnectorConfig config, As400StreamingChangeEventSourceMetrics streamingMetrics, List<FileFilter> includes) {
         super();
         this.config = config;
-        this.isSecure = config.isSecure();
+        this.isSecure = config.getJdbcConfig().getBoolean("secure", config.isSecure());
         this.streamingMetrics = streamingMetrics;
         try {
             System.setProperty("com.ibm.as400.access.AS400.guiAvailable", "False");


### PR DESCRIPTION
Change check for "secure" so it takes value of JdbcConfig instead of default value in from As400ConnectorConfig