### PR TITLE
[ci] Skip checkstyle on jt400-override-ccsid

### DIFF
--- a/jt400-override-ccsid/pom.xml
+++ b/jt400-override-ccsid/pom.xml
@@ -60,6 +60,14 @@
                     <enableAssertions>true</enableAssertions>
                 </configuration>
             </plugin>
+            <!-- The code in this project comes for another one so it does not conform to Debezium coding standards -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
         </plugins>
         <resources>
             <!-- Apply the properties set in the POM to the resource files -->


### PR DESCRIPTION
This should address the IBMi failures on CI builds. It does not seem that its expected that jt400-override-ccsid should be formatted as the code is copy-n-paste from elsewhere. 