### PR TITLE
DBZ-8214 trim whitespace from receiver so we can compare positions

### DIFF
--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/rjne0200/EntryHeader.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/rjne0200/EntryHeader.java
@@ -46,8 +46,8 @@ public class EntryHeader {
         this.commitCycle = commitCycle;
         this.endOffset = endOffset;
         this.pointerHandle = pointerHandle;
-        this.receiver = receiver;
-        this.receiverLibrary = receiverLibrary;
+        this.receiver = StringHelpers.safeTrim(receiver);
+        this.receiverLibrary = StringHelpers.safeTrim(receiverLibrary);
     }
 
     @Override


### PR DESCRIPTION
trimming whitespace here for our journal position fixes our comparison where we test if we have already seen the first record we request