### PR TITLE
DBZ-9183 Schema Name Adjustment mode

### DIFF
--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorConfig.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorConfig.java
@@ -220,7 +220,8 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
                         HOSTNAME, USER, PASSWORD, SCHEMA, BUFFER_SIZE,
                         SOCKET_TIMEOUT, FROM_CCSID, TO_CCSID, SECURE,
                         DIAGNOSTICS_FOLDER)
-                .connector()
+                .connector(
+                        SCHEMA_NAME_ADJUSTMENT_MODE)
                 .events(
                         As400OffsetContext.EVENT_SEQUENCE_FIELD,
                         As400OffsetContext.RECEIVER_FIELD,

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorTask.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorTask.java
@@ -68,7 +68,7 @@ public class As400ConnectorTask extends BaseSourceTask<As400Partition, As400Offs
         final TopicNamingStrategy<TableId> topicNamingStrategy = connectorConfig
                 .getTopicNamingStrategy(As400ConnectorConfig.TOPIC_NAMING_STRATEGY, true);
 
-        final SchemaNameAdjuster schemaNameAdjuster = SchemaNameAdjuster.AVRO;
+        final SchemaNameAdjuster schemaNameAdjuster = connectorConfig.schemaNameAdjuster();
 
         final MainConnectionProvidingConnectionFactory<As400JdbcConnection> jdbcConnectionFactory = new DefaultMainConnectionProvidingConnectionFactory<>(
                 () -> new As400JdbcConnection(connectorConfig.getJdbcConfig()));


### PR DESCRIPTION
Hello,
We got some db2 columns named XXX$123 and XXX#123 so the default avro naming create duplicate tables (XXX_123). avro_unicode will cover this overlap.