### PR TITLE
DBZ-8966 use CustomConverter in serviceRegistry and remove usage in ConnectorConfiguration

### DIFF
--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400DatabaseSchema.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400DatabaseSchema.java
@@ -16,6 +16,7 @@ import io.debezium.connector.db2as400.conversion.As400DefaultValueConverter;
 import io.debezium.connector.db2as400.conversion.SchemaInfoConversion;
 import io.debezium.ibmi.db2.journal.retrieve.JdbcFileDecoder;
 import io.debezium.ibmi.db2.journal.retrieve.SchemaCacheIF;
+import io.debezium.relational.CustomConverterRegistry;
 import io.debezium.relational.RelationalDatabaseSchema;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
@@ -33,11 +34,11 @@ public class As400DatabaseSchema extends RelationalDatabaseSchema implements Sch
     private final JdbcFileDecoder fileDecoder;
 
     public As400DatabaseSchema(As400ConnectorConfig config, As400JdbcConnection jdbcConnection,
-                               TopicNamingStrategy<TableId> topicSelector, SchemaNameAdjuster schemaNameAdjuster) {
+                               TopicNamingStrategy<TableId> topicSelector, SchemaNameAdjuster schemaNameAdjuster, CustomConverterRegistry customConverterRegistry) {
         super(config, topicSelector, config.getTableFilters().dataCollectionFilter(), config.getColumnFilter(),
                 new TableSchemaBuilder(new As400ValueConverters(config.getDecimalMode()),
                         new As400DefaultValueConverter(), schemaNameAdjuster,
-                        config.customConverterRegistry(), config.getSourceInfoStructMaker().schema(),
+                        customConverterRegistry, config.getSourceInfoStructMaker().schema(),
                         config.getFieldNamer(), false),
                 false, config.getKeyMapper());
 


### PR DESCRIPTION
## Context

Currently, the `CustomConverterRegistry` is retrieved from `ConnectorConfiguration`. This can lead to some issues:

- Multiple points of retrieval for the registry
- Mixing configuration with business logic

## Decision

Use the `ServiceRegistry` to retrieve the `CustomConverterRegistry`.

#depends https://github.com/debezium/debezium/pull/6553