### PR TITLE
DBZ-9225: Registering DebeziumHeaderProducerProvider for AS400 connector

### DIFF
--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorTask.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorTask.java
@@ -14,7 +14,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import io.debezium.connector.common.DebeziumHeaderProducerProvider;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,6 +25,7 @@ import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.connector.common.BaseSourceTask;
 import io.debezium.connector.common.CdcSourceTaskContext;
 import io.debezium.connector.common.DebeziumHeaderProducer;
+import io.debezium.connector.common.DebeziumHeaderProducerProvider;
 import io.debezium.connector.db2as400.metrics.As400ChangeEventSourceMetricsFactory;
 import io.debezium.connector.db2as400.metrics.As400StreamingChangeEventSourceMetrics;
 import io.debezium.converters.custom.CustomConverterServiceProvider;


### PR DESCRIPTION
Fixed a NullPointerException encountered during event retrieval, caused by the DebeziumHeaderProducerProvider not being registered in the ServiceRegistry.
AS400ConnectorIT was un locally with Pub400 credentials and completed successfully.

`Consumed record 2 / 2 (0 more)
{"sourcePartition" : {"server" : "server_J_1"}, "sourceOffset" : {"offset.event_sequence" : "217", "offset.receiver_library" : "TES2", "offset.time" : "1752671893", "offset.receiver" : "MRCV01", "table.include.list" : "TES2.TESTT", "offset.processed" : "true", "snapshot_completed" : "true"}, "topic" : "server_J_1.TES2.TESTT", "kafkaPartition" : null, "key" : {"ID" : "3"}, "value" : {"before" : null, "after" : {"ID" : "3", "VALUE" : "third"}, "source" : {"version" : "3.3.0-SNAPSHOT", "connector" : "ibmi", "name" : "server_J_1", "ts_ms" : "1752671893208", "snapshot" : "last", "db" : "db name", "sequence" : null, "ts_us" : "1752671893208656", "ts_ns" : "1752671893208656000"}, "transaction" : null, "op" : "c", "ts_ms" : "1752671893846", "ts_us" : "1752671893846332", "ts_ns" : "1752671893846332700"}}
2025-07-16 15:18:14,176 INFO   As400ConnectorIT||test  Stopping the connector   [io.debezium.connector.db2as400.As400ConnectorIT]
2025-07-16 15:18:14,176 INFO   As400ConnectorIT||test  Stopping the engine   [io.debezium.connector.db2as400.As400ConnectorIT]
2025-07-16 15:18:14,176 INFO   As400ConnectorIT||test  Engine state has changed from 'POLLING_TASKS' to 'STOPPING'   [io.debezium.embedded.async.AsyncEmbeddedEngine]
2025-07-16 15:18:14,177 INFO   As400ConnectorIT||engine  Task interrupted while polling.   [io.debezium.embedded.async.AsyncEmbeddedEngine]
2025-07-16 15:18:14,178 INFO   ||  Stopping down connector   [io.debezium.connector.common.BaseSourceTask]
2025-07-16 15:18:14,317 INFO   Db2As400_Server||streaming  Finished streaming   [io.debezium.pipeline.ChangeEventSourceCoordinator]
2025-07-16 15:18:14,318 INFO   ||  Interrupted is shuttingdown: true   [io.debezium.connector.db2as400.As400StreamingChangeEventSource]
2025-07-16 15:18:14,320 INFO   ||  SignalProcessor stopped   [io.debezium.pipeline.signal.SignalProcessor]
2025-07-16 15:18:14,321 INFO   ||  Debezium ServiceRegistry stopped.   [io.debezium.service.DefaultServiceRegistry]
2025-07-16 15:18:14,322 INFO   As400ConnectorIT||test  Stopped task #1 out of 1 tasks (it took 143 ms to stop the task).   [io.debezium.embedded.async.AsyncEmbeddedEngine]
2025-07-16 15:18:14,323 INFO   As400ConnectorIT||engine  Engine is stopped.   [io.debezium.embedded.async.AsyncEmbeddedEngine]
2025-07-16 15:18:14,324 INFO   As400ConnectorIT||engine  Engine state has changed from 'STOPPING' to 'STOPPED'   [io.debezium.embedded.async.AsyncEmbeddedEngine]
2025-07-16 15:18:14,324 INFO   As400ConnectorIT||engine  Connector 'io.debezium.connector.db2as400.As400RpcConnector' completed normally.   [io.debezium.connector.db2as400.As400ConnectorIT]
2025-07-16 15:18:14,449 INFO   As400ConnectorIT||test  Interrupting the engine   [io.debezium.connector.db2as400.As400ConnectorIT]
2025-07-16 15:18:14,459 INFO   As400ConnectorIT||test  Stopping the connector   [io.debezium.connector.db2as400.As400ConnectorIT]
2025-07-16 15:18:14,461 INFO   As400ConnectorIT||test  Test io.debezium.connector.db2as400.As400ConnectorIT#shouldSnapshotAndStream succeeded   [io.debezium.connector.db2as400.As400ConnectorIT]`