### PR TITLE
DBZ-9291: Add metadata to IBMi connector to handle multi-journal

### DIFF
--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400OffsetContext.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400OffsetContext.java
@@ -132,8 +132,13 @@ public class As400OffsetContext extends CommonOffsetContext<SourceInfo> {
         return sourceInfo.schema();
     }
 
-    public void setSourceTime(Instant time) {
-        sourceInfo.setSourceTime(time);
+    public void setSourceTime(Instant timestamp) {
+        sourceInfo.setSourceTime(timestamp);
+        sourceInfo.setReceiver(position.getReceiver().name());
+        sourceInfo.setReceiverLib(position.getReceiver().library());
+        sourceInfo.setSequence(position.getOffset().toString());
+        String time = Long.toString(position.getTimeOfLastProcessed().getEpochSecond());
+        sourceInfo.setEventTime(time);
     }
 
     @Override
@@ -144,6 +149,11 @@ public class As400OffsetContext extends CommonOffsetContext<SourceInfo> {
     @Override
     public void event(DataCollectionId collectionId, Instant timestamp) {
         sourceInfo.setSourceTime(timestamp);
+        sourceInfo.setReceiver(position.getReceiver().name());
+        sourceInfo.setReceiverLib(position.getReceiver().library());
+        sourceInfo.setSequence(position.getOffset().toString());
+        String time = Long.toString(position.getTimeOfLastProcessed().getEpochSecond());
+        sourceInfo.setEventTime(time);
         // sourceInfo.tableEvent((TableId) collectionId);
     }
 

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400SourceInfoStructMaker.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400SourceInfoStructMaker.java
@@ -5,6 +5,10 @@
  */
 package io.debezium.connector.db2as400;
 
+import static io.debezium.connector.db2as400.SourceInfo.EVENT_TIME_KEY;
+import static io.debezium.connector.db2as400.SourceInfo.RECEIVER_KEY;
+import static io.debezium.connector.db2as400.SourceInfo.RECEIVER_LIBRARY_KEY;
+
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 
@@ -22,7 +26,9 @@ public class As400SourceInfoStructMaker extends AbstractSourceInfoStructMaker<So
                 // TODO add in table info
                 // .field(SourceInfo.SCHEMA_NAME_KEY, Schema.STRING_SCHEMA)
                 // .field(SourceInfo.TABLE_NAME_KEY, Schema.STRING_SCHEMA)
-                // TODO add in offset
+                .field(RECEIVER_KEY, Schema.STRING_SCHEMA)
+                .field(RECEIVER_LIBRARY_KEY, Schema.STRING_SCHEMA)
+                .field(EVENT_TIME_KEY, Schema.STRING_SCHEMA)
                 .build();
     }
 
@@ -36,7 +42,9 @@ public class As400SourceInfoStructMaker extends AbstractSourceInfoStructMaker<So
         final Struct ret = super.commonStruct(sourceInfo);
         // .put(SourceInfo.SCHEMA_NAME_KEY, sourceInfo.getTableId().schema())
         // .put(SourceInfo.TABLE_NAME_KEY, sourceInfo.getTableId().table());
-
+        ret.put(RECEIVER_KEY, sourceInfo.getReceiver() == null ? "null" : sourceInfo.getReceiver());
+        ret.put(RECEIVER_LIBRARY_KEY, sourceInfo.getReceiverLib() == null ? "null" : sourceInfo.getReceiverLib());
+        ret.put(EVENT_TIME_KEY, sourceInfo.getEventTime() == null ? "null" : sourceInfo.getEventTime());
         return ret;
     }
 }

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/SourceInfo.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/SourceInfo.java
@@ -22,8 +22,15 @@ public class SourceInfo extends BaseSourceInfo {
 
     public static final String SNAPSHOT_KEY = "snapshot";
     public static final String JOURNAL_KEY = "journal";
+    public static final String RECEIVER_KEY = "receiver";
+    public static final String RECEIVER_LIBRARY_KEY = "receiver_library";
+    public static final String EVENT_TIME_KEY = "event_time";
     private Instant sourceTime;
     private String databaseName;
+    private String receiver;
+    private String receiverLib;
+    private String sequence;
+    private String eventTime;
 
     protected SourceInfo(As400ConnectorConfig connectorConfig) {
         super(connectorConfig);
@@ -42,5 +49,38 @@ public class SourceInfo extends BaseSourceInfo {
     @Override
     protected String database() {
         return databaseName;
+    }
+
+    public String getReceiver() {
+        return receiver;
+    }
+
+    public void setReceiver(String receiver) {
+        this.receiver = receiver;
+    }
+
+    public String getReceiverLib() {
+        return receiverLib;
+    }
+
+    public void setReceiverLib(String receiverLib) {
+        this.receiverLib = receiverLib;
+    }
+
+    @Override
+    protected String sequence() {
+        return sequence;
+    }
+
+    public void setSequence(String sequence) {
+        this.sequence = sequence;
+    }
+
+    public String getEventTime() {
+        return eventTime;
+    }
+
+    public void setEventTime(String eventTime) {
+        this.eventTime = eventTime;
     }
 }


### PR DESCRIPTION
Please refer to https://issues.redhat.com/browse/DBZ-9291 for more details,

This small PR intends to add several metadata fields that are very helpful to order events across multiple journals (each table can have its own journal with ibmi)