### PR TITLE
debezium/dbz#453 Derive field group order implicitly from ConfigDefinition ordering

### DIFF
--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorConfig.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorConfig.java
@@ -248,13 +248,14 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
     public static ConfigDef configDef() {
         final ConfigDef c = RelationalDatabaseConnectorConfig.CONFIG_DEFINITION.edit()
                 .name("ibmi")
-                .type(
+                .group(Field.Group.CONNECTION,
                         HOSTNAME, USER, PASSWORD, SCHEMA, BUFFER_SIZE,
                         SOCKET_TIMEOUT, FROM_CCSID, TO_CCSID, SECURE,
                         DIAGNOSTICS_FOLDER, TRIM_NON_XML_CHARSEQUENCE_FIELD_MODE, JOURNAL_CACHE_ADDITIONAL_DELAY)
-                .connector(
-                        SCHEMA_NAME_ADJUSTMENT_MODE)
-                .events(
+                .group(Field.Group.CONNECTOR_SNAPSHOT,
+                        SNAPSHOT_MODE)
+                .group(Field.Group.CONNECTOR,
+                        SCHEMA_NAME_ADJUSTMENT_MODE,
                         As400OffsetContext.EVENT_SEQUENCE_FIELD,
                         As400OffsetContext.RECEIVER_FIELD,
                         As400OffsetContext.RECEIVER_LIBRARY_FIELD,
@@ -265,7 +266,7 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     public static final Field SNAPSHOT_MODE = Field.create("snapshot.mode")
             .withDisplayName("Snapshot mode")
-            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT, 0))
+            .withGroup(Field.createGroupEntry(Field.Group.CONNECTOR_SNAPSHOT))
             .withEnum(SnapshotMode.class, SnapshotMode.INITIAL)
             .withWidth(Width.SHORT)
             .withImportance(Importance.MEDIUM)


### PR DESCRIPTION
## Summary

Follow-up to debezium/debezium#7286, which removed explicit `positionInGroup` numbers from `Field.createGroupEntry()` calls across the main connectors and derives group order implicitly from `ConfigDefinition` ordering instead.

This applies the same change here:

- Removed the explicit position number from `SNAPSHOT_MODE`'s `createGroupEntry` call.
- Migrated `configDef()` from the old `.type()/.connector()/.events()` API to the
  new `.group(Field.Group, ...)` API.
- Fixed a pre-existing bug along the way: `SNAPSHOT_MODE` was declared but never
  added to the `ConfigDef`, so it wasn't actually exposed/documented.

## Note

I think this depends on debezium/debezium#7286, which is not yet merged. The `ConfigDefinitionEditor.group(...)` method used here doesn't exist in the current `debezium-config` snapshot, so this PR will not build until #7286 merges and a new core snapshot/release is available.