### PR TITLE
debezium/dbz#2201 Support tables across multiple libraries

### DIFF
--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorConfig.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorConfig.java
@@ -6,7 +6,9 @@
 package io.debezium.connector.db2as400;
 
 import java.time.Instant;
+import java.util.LinkedHashSet;
 import java.util.Optional;
+import java.util.Set;
 
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
@@ -169,6 +171,44 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
 
     public String getSchema() {
         return config.getString(SCHEMA).toUpperCase();
+    }
+
+    /**
+     * The set of libraries (schemas) to capture, derived from the raw {@code table.include.list}.
+     *
+     * <p>A connector may capture tables spread across several libraries (e.g.
+     * {@code LIB1.T1,LIB2.T2}). Each qualified entry contributes its own library; unqualified
+     * entries fall back to {@link #getSchema()}, which is always included.
+     *
+     */
+    public Set<String> getCaptureSchemas() {
+        final Set<String> schemas = new LinkedHashSet<>();
+        final String defaultSchema = getSchema();
+        schemas.add(defaultSchema);
+
+        final String includeList = config.getString(TABLE_INCLUDE_LIST);
+        if (includeList == null || includeList.isBlank()) {
+            return schemas;
+        }
+        for (String entry : includeList.split(",")) {
+            entry = entry.trim();
+            if (entry.isEmpty()) {
+                continue;
+            }
+            int o = entry.lastIndexOf('.');
+            if (o <= 0) {
+                schemas.add(defaultSchema);
+                continue;
+            }
+            String schemaName = entry.substring(0, o);
+            // Handle the "database.schema.table" form: keep only the schema segment.
+            o = schemaName.lastIndexOf('.');
+            if (o > 0) {
+                schemaName = schemaName.substring(o + 1);
+            }
+            schemas.add(schemaName.toUpperCase());
+        }
+        return schemas;
     }
 
     public Integer getJournalBufferSize() {

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorConfig.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorConfig.java
@@ -6,7 +6,10 @@
 package io.debezium.connector.db2as400;
 
 import java.time.Instant;
-import java.util.LinkedHashSet;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -182,14 +185,21 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
      *
      */
     public Set<String> getCaptureSchemas() {
-        final Set<String> schemas = new LinkedHashSet<>();
-        final String defaultSchema = getSchema();
-        schemas.add(defaultSchema);
+        return getCaptured().keySet();
+    }
 
-        final String includeList = config.getString(TABLE_INCLUDE_LIST);
+    public Map<String, List<String>> getCaptured() {
+        final Map<String, List<String>> map = new LinkedHashMap<>();
+        map.put(getSchema(), new ArrayList<>());
+        addIncludes(map, config.getString(TABLE_INCLUDE_LIST));
+        return map;
+    }
+
+    public void addIncludes(Map<String, List<String>> map, String includeList) {
         if (includeList == null || includeList.isBlank()) {
-            return schemas;
+            return;
         }
+        final String defaultSchema = getSchema();
         for (String entry : includeList.split(",")) {
             entry = entry.trim();
             if (entry.isEmpty()) {
@@ -197,18 +207,18 @@ public class As400ConnectorConfig extends RelationalDatabaseConnectorConfig {
             }
             int o = entry.lastIndexOf('.');
             if (o <= 0) {
-                schemas.add(defaultSchema);
+                map.computeIfAbsent(defaultSchema, k -> new ArrayList<>()).add(entry);
                 continue;
             }
             String schemaName = entry.substring(0, o);
+            final String tableName = entry.substring(o + 1);
             // Handle the "database.schema.table" form: keep only the schema segment.
             o = schemaName.lastIndexOf('.');
             if (o > 0) {
                 schemaName = schemaName.substring(o + 1);
             }
-            schemas.add(schemaName.toUpperCase());
+            map.computeIfAbsent(schemaName.toUpperCase(), k -> new ArrayList<>()).add(tableName);
         }
-        return schemas;
     }
 
     public Integer getJournalBufferSize() {

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorTask.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ConnectorTask.java
@@ -126,14 +126,14 @@ public class As400ConnectorTask extends BaseSourceTask<As400Partition, As400Offs
         final As400StreamingChangeEventSourceMetrics streamingMetrics = new As400StreamingChangeEventSourceMetrics(
                 taskContext, queue, metadataProvider, schema::tableIds);
 
-        String configuredIncludes = newConfig.tableIncludeList();
-        String signalDataCollection = config.getString(RelationalDatabaseConnectorConfig.SIGNAL_DATA_COLLECTION);
+        final Map<String, List<String>> captured = connectorConfig.getCaptured();
+        final String signalDataCollection = config.getString(RelationalDatabaseConnectorConfig.SIGNAL_DATA_COLLECTION);
         if (!Strings.isNullOrBlank(signalDataCollection)) {
-            configuredIncludes = configuredIncludes.length() > 0 ? String.format("%s,%s", configuredIncludes, signalDataCollection) : "";
+            // Ensure the signal table is journalled alongside the captured tables.
+            connectorConfig.addIncludes(captured, signalDataCollection);
         }
 
-        final List<FileFilter> shortIncludes = jdbcConnection.shortIncludes(schema.getSchemaName(),
-                configuredIncludes);
+        final List<FileFilter> shortIncludes = jdbcConnection.shortIncludes(captured);
 
         final long cacheWait = JournalInfoRetrieval.getJournalCacheDurationInMilliseconds(jdbcConnection);
 

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400JdbcConnection.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400JdbcConnection.java
@@ -13,7 +13,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -109,34 +108,13 @@ public class As400JdbcConnection extends JdbcConnection implements Connect<Conne
         return this.connectionString(URL_PATTERN);
     }
 
-    public List<FileFilter> shortIncludes(String schema, String includes) {
-        if (includes == null || includes.isBlank()) {
-            return Collections.<FileFilter> emptyList();
-        }
-        final String[] incs = includes.split(",");
-        final List<FileFilter> r = new ArrayList<>();
-        for (String tableName : incs) {
-            String schemaName = "";
-            int o = tableName.lastIndexOf('.');
-            if (o > 0) {
-                schemaName = tableName.substring(0, o);
-                tableName = tableName.substring(o + 1);
+    public List<FileFilter> shortIncludes(Map<String, List<String>> captured) {
+        List<FileFilter> r = new ArrayList<>();
+        for (Map.Entry<String, List<String>> e : captured.entrySet()) {
+            String schema = e.getKey();
+            for (String table : e.getValue()) {
+                getSystemName(schema, table).map(x -> r.add(new FileFilter(schema, x)));
             }
-
-            // This handles the case where the table name has been specified as "database.schema.table"
-            if (!"".equals(schemaName)) {
-                o = schemaName.lastIndexOf('.');
-                if (o > 0) {
-                    schemaName = schemaName.substring(o + 1);
-                }
-            }
-
-            if ("".equals(schemaName)) {
-                schemaName = schema;
-            }
-
-            final String tableSchema = schemaName;
-            getSystemName(tableSchema, tableName).map(x -> r.add(new FileFilter(tableSchema, x)));
         }
         return r;
     }

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400SnapshotChangeEventSource.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400SnapshotChangeEventSource.java
@@ -7,6 +7,7 @@ package io.debezium.connector.db2as400;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -73,8 +74,13 @@ public class As400SnapshotChangeEventSource
     @Override
     protected Set<TableId> getAllTableIds(RelationalSnapshotContext<As400Partition, As400OffsetContext> snapshotContext)
             throws Exception {
-        final Set<TableId> tables = jdbcConnection.readTableNames(jdbcConnection.getRealDatabaseName(),
-                connectorConfig.getSchema(), null, new String[]{ "TABLE" });
+        // A single connector may capture tables across several libraries (sharing one journal),
+        // so discover tables in every library referenced by the include list, not just the default.
+        final String databaseName = jdbcConnection.getRealDatabaseName();
+        final Set<TableId> tables = new LinkedHashSet<>();
+        for (final String schema : connectorConfig.getCaptureSchemas()) {
+            tables.addAll(jdbcConnection.readTableNames(databaseName, schema, null, new String[]{ "TABLE" }));
+        }
         return tables;
     }
 

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400ConnectorConfigCaptureSchemasTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400ConnectorConfigCaptureSchemasTest.java
@@ -6,6 +6,10 @@
 package io.debezium.connector.db2as400;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -70,5 +74,69 @@ public class As400ConnectorConfigCaptureSchemasTest {
 
         // Then only the default schema is captured
         assertThat(config.getCaptureSchemas()).containsExactly("LIB1");
+    }
+
+    @Test
+    public void capturesTablesPerLibraryWithFullTableName() {
+        // Given qualified entries across two libraries
+        final As400ConnectorConfig config = configWith("LIB1", "LIB1.T1,LIB2.T2");
+
+        // Then each library keeps its full (untruncated) table name
+        assertThat(config.getCaptured()).containsOnly(
+                entry("LIB1", List.of("T1")),
+                entry("LIB2", List.of("T2")));
+    }
+
+    @Test
+    public void capturesUnqualifiedTablesUnderDefaultSchema() {
+        // Given an include list with no library prefixes
+        final As400ConnectorConfig config = configWith("MYLIB", "T1,T2");
+
+        // Then both tables are captured under the default schema
+        assertThat(config.getCaptured()).containsOnly(entry("MYLIB", List.of("T1", "T2")));
+    }
+
+    @Test
+    public void mixedQualifiedAndUnqualifiedUnderDefaultSchemaAreKept() {
+        // Given a qualified and an unqualified table that both resolve to the default schema
+        final As400ConnectorConfig config = configWith("LIB1", "LIB1.T1,T2");
+
+        // Then neither entry clobbers the other
+        assertThat(config.getCaptured()).containsOnly(entry("LIB1", List.of("T1", "T2")));
+    }
+
+    @Test
+    public void databaseSchemaTableFormKeepsTableName() {
+        // Given a fully-qualified database.schema.table entry
+        final As400ConnectorConfig config = configWith("LIB1", "MYDB.LIB3.T1");
+
+        // Then the library is the schema segment and the table name is preserved
+        assertThat(config.getCaptured()).containsOnly(
+                entry("LIB1", List.of()),
+                entry("LIB3", List.of("T1")));
+    }
+
+    @Test
+    public void uppercasesLibraryButPreservesRawTableCasing() {
+        // Given a lowercase library and a mixed-case table name
+        final As400ConnectorConfig config = configWith("LIB1", "lib2.myTable");
+
+        // Then the library is uppercased (for dedup) but the table name is looked up verbatim
+        assertThat(config.getCaptured()).containsOnly(
+                entry("LIB1", List.of()),
+                entry("LIB2", List.of("myTable")));
+    }
+
+    @Test
+    public void addIncludesFoldsInSignalDataCollection() {
+        // Given a captured map and a separately-configured signal data collection
+        final As400ConnectorConfig config = configWith("LIB1", "LIB1.T1");
+        final Map<String, List<String>> captured = config.getCaptured();
+
+        // When the signal table is folded in
+        config.addIncludes(captured, "LIB1.SIGNALS");
+
+        // Then it is journalled alongside the captured tables
+        assertThat(captured).containsOnly(entry("LIB1", List.of("T1", "SIGNALS")));
     }
 }

--- a/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400ConnectorConfigCaptureSchemasTest.java
+++ b/debezium-connector-ibmi/src/test/java/io/debezium/connector/db2as400/As400ConnectorConfigCaptureSchemasTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.db2as400;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.debezium.config.CommonConnectorConfig;
+import io.debezium.config.Configuration;
+import io.debezium.relational.RelationalDatabaseConnectorConfig;
+
+public class As400ConnectorConfigCaptureSchemasTest {
+
+    private As400ConnectorConfig configWith(String schema, String includeList) {
+        Configuration.Builder builder = Configuration.create()
+                .with(CommonConnectorConfig.TOPIC_PREFIX, "serverX")
+                .with(As400ConnectorConfig.DATABASE_NAME, "serverX")
+                .with(As400ConnectorConfig.SCHEMA, schema);
+        if (includeList != null) {
+            builder = builder.with(RelationalDatabaseConnectorConfig.TABLE_INCLUDE_LIST, includeList);
+        }
+        return new As400ConnectorConfig(builder.build());
+    }
+
+    @Test
+    public void unionsLibrariesFromQualifiedIncludeList() {
+        // Given an include list spanning two libraries
+        final As400ConnectorConfig config = configWith("LIB1", "LIB1.T1,LIB2.T2");
+
+        // When deriving the capture schemas
+        // Then both libraries are returned
+        assertThat(config.getCaptureSchemas()).containsExactlyInAnyOrder("LIB1", "LIB2");
+    }
+
+    @Test
+    public void fallsBackToDefaultSchemaForUnqualifiedEntries() {
+        // Given an include list with no library prefixes
+        final As400ConnectorConfig config = configWith("MYLIB", "T1,T2");
+
+        // Then only the default schema is captured
+        assertThat(config.getCaptureSchemas()).containsExactly("MYLIB");
+    }
+
+    @Test
+    public void normalizesCaseAndDeduplicates() {
+        // Given a mix of cases, a duplicate, and an unqualified entry
+        final As400ConnectorConfig config = configWith("LIB1", "lib2.t1,LIB2.T2,T3");
+
+        // Then libraries are uppercased and deduplicated, with the default schema included
+        assertThat(config.getCaptureSchemas()).containsExactlyInAnyOrder("LIB1", "LIB2");
+    }
+
+    @Test
+    public void handlesDatabaseSchemaTableForm() {
+        // Given a fully-qualified database.schema.table entry
+        final As400ConnectorConfig config = configWith("LIB1", "MYDB.LIB3.T1");
+
+        // Then only the schema segment is taken as the library
+        assertThat(config.getCaptureSchemas()).containsExactlyInAnyOrder("LIB1", "LIB3");
+    }
+
+    @Test
+    public void returnsOnlyDefaultSchemaWhenIncludeListAbsent() {
+        // Given no include list
+        final As400ConnectorConfig config = configWith("LIB1", null);
+
+        // Then only the default schema is captured
+        assertThat(config.getCaptureSchemas()).containsExactly("LIB1");
+    }
+}

--- a/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/JournalInfoRetrieval.java
+++ b/journal-parsing/src/main/java/io/debezium/ibmi/db2/journal/retrieve/JournalInfoRetrieval.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -154,28 +155,28 @@ public class JournalInfoRetrieval {
     }
 
     public JournalInfo getJournal(AS400 as400, String schema, List<FileFilter> includes) throws IllegalStateException {
+        if (includes.isEmpty()) {
+            return getJournal(as400, schema);
+        }
+        final Set<JournalInfo> jis = new HashSet<>();
+        final Set<String> libraries = new TreeSet<>();
         try {
-            if (includes.isEmpty()) {
-                return getJournal(as400, schema);
-            }
-            final Set<JournalInfo> jis = new HashSet<>();
             for (final FileFilter f : includes) {
-                if (!schema.equals(f.schema())) {
-                    throw new IllegalArgumentException(
-                            String.format("schema %s does not match for filter: %s", schema, f));
-                }
-                final JournalInfo ji = getJournal(as400, f.schema(), f.table());
-                jis.add(ji);
+                libraries.add(f.schema());
+                jis.add(getJournal(as400, f.schema(), f.table()));
             }
-            if (jis.size() > 1) {
-                throw new IllegalArgumentException(
-                        String.format("more than one journal for the set of tables journals: %s", jis));
-            }
-            return jis.iterator().next();
         }
         catch (final Exception e) {
             throw new IllegalStateException("unable to retrieve journal details", e);
         }
+        if (jis.size() > 1) {
+            throw new IllegalStateException(String.format(
+                    "tables span more than one journal, which is not supported: a single connector must "
+                            + "capture tables that all journal to the same journal. Libraries requested: %s; "
+                            + "distinct journals found: %s",
+                    libraries, jis));
+        }
+        return jis.iterator().next();
     }
 
     public JournalInfo getJournal(AS400 as400, String schema, String table) throws Exception {

--- a/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/JournalInfoRetrievalGetJournalTest.java
+++ b/journal-parsing/src/test/java/io/debezium/ibmi/db2/journal/retrieve/JournalInfoRetrievalGetJournalTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.ibmi.db2.journal.retrieve;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.ibm.as400.access.AS400;
+
+@ExtendWith(MockitoExtension.class)
+class JournalInfoRetrievalGetJournalTest {
+
+    @Mock
+    AS400 as400;
+
+    private final JournalInfo journalA = new JournalInfo("JRN", "JRNLIB", false);
+    private final JournalInfo journalB = new JournalInfo("OTHERJRN", "JRNLIB", false);
+
+    @Test
+    void multipleLibrariesSharingOneJournalResolveToSingleJournal() throws Exception {
+        // Given two tables in two different libraries that both journal to JRN
+        final JournalInfoRetrieval retrieval = spy(new JournalInfoRetrieval(0L, 0L, 0L));
+        doReturn(journalA).when(retrieval).getJournal(as400, "LIB1", "T1");
+        doReturn(journalA).when(retrieval).getJournal(as400, "LIB2", "T2");
+
+        // When resolving the journal for the include list
+        final JournalInfo result = retrieval.getJournal(as400, "LIB1",
+                List.of(new FileFilter("LIB1", "T1"), new FileFilter("LIB2", "T2")));
+
+        // Then the shared journal is returned without error
+        assertEquals(journalA, result);
+    }
+
+    @Test
+    void multipleLibrariesWithDistinctJournalsFailWithExplicitMessage() throws Exception {
+        // Given two tables in two libraries that journal to different journals
+        final JournalInfoRetrieval retrieval = spy(new JournalInfoRetrieval(0L, 0L, 0L));
+        doReturn(journalA).when(retrieval).getJournal(as400, "LIB1", "T1");
+        doReturn(journalB).when(retrieval).getJournal(as400, "LIB2", "T2");
+
+        // When resolving the journal for the include list
+        final IllegalStateException ex = assertThrows(IllegalStateException.class,
+                () -> retrieval.getJournal(as400, "LIB1",
+                        List.of(new FileFilter("LIB1", "T1"), new FileFilter("LIB2", "T2"))));
+
+        // Then the failure clearly names the multi-journal situation and the libraries involved
+        assertTrue(ex.getMessage().contains("more than one journal"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("LIB1"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("LIB2"), ex.getMessage());
+    }
+}


### PR DESCRIPTION
Fixes debezium/dbz#2201

This PR allows to define a debezium.table.include.list with "SCHEMA1.TABLE1, SHEMA2.TABLE2, etc." provided that all tables are registered under a single ibmi journal.

previously, connector would require all tables to be defined under a single schema