### PR TITLE
debezium/dbz#2204 use reliable close method to clear pst cache

### DIFF
--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400JdbcConnection.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400JdbcConnection.java
@@ -334,7 +334,7 @@ public class As400JdbcConnection extends JdbcConnection implements Connect<Conne
         if (!conn.isValid(3)) {
             log.info("connection dead closing");
             try {
-                conn.close();
+                super.close();
             }
             catch (final Exception e) {
                 // we can ignore this we just need a new connection


### PR DESCRIPTION
Fixes debezium/dbz#2204

If a IBMi connection is invalidated, closed and reopened, it's essential to call super.close() to clear the old prepared statement cache to avoid an SQL exception when processing an ongoing incremental snapshot.