### PR TITLE
debezium/dbz#2153 Change As400ValueConverters to use "time.precision.mode"

### DIFF
--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ValueConverters.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ValueConverters.java
@@ -30,13 +30,11 @@ public class As400ValueConverters extends JdbcValueConverters {
 
     /**
      * Time precision in AS400 DB2 is defined in scale. When not explicitly
-     * declared, scale is 6 (microseconds).  When no scale is present, we
-     * return a scale of 0 (no fractional seconds) to handle the case of
-     * TIMESTAMP(0) declarations.
+     * declared, scale is 6 (microseconds).
      */
     @Override
     protected int getTimePrecision(Column column) {
-        return column.scale().orElse(0);
+        return column.scale().orElse(-1);
     }
 
     @Override

--- a/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ValueConverters.java
+++ b/debezium-connector-ibmi/src/main/java/io/debezium/connector/db2as400/As400ValueConverters.java
@@ -13,7 +13,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.debezium.jdbc.JdbcValueConverters;
-import io.debezium.jdbc.TemporalPrecisionMode;
 import io.debezium.relational.Column;
 
 /**
@@ -25,8 +24,19 @@ public class As400ValueConverters extends JdbcValueConverters {
     private final As400ConnectorConfig config;
 
     public As400ValueConverters(DecimalMode decimalMode, As400ConnectorConfig config) {
-        super(decimalMode, TemporalPrecisionMode.ADAPTIVE, ZoneOffset.UTC, null, null, null);
+        super(decimalMode, config.getTemporalPrecisionMode(), ZoneOffset.UTC, null, null, null);
         this.config = config;
+    }
+
+    /**
+     * Time precision in AS400 DB2 is defined in scale. When not explicitly
+     * declared, scale is 6 (microseconds).  When no scale is present, we
+     * return a scale of 0 (no fractional seconds) to handle the case of
+     * TIMESTAMP(0) declarations.
+     */
+    @Override
+    protected int getTimePrecision(Column column) {
+        return column.scale().orElse(0);
     }
 
     @Override


### PR DESCRIPTION
Fixes debezium/dbz#2153

Change As400ValueConverters from a hardcoded TemporalPrecisionMode.ADAPTIVE to use value of "time.precision.mode" connector property.  As the base class RelationalDatabaseConnectorConfig defaults to TemporalPrecisionMode.ADAPTIVE, the default configuration behavior is unchanged.

To fix cases were ADAPTIVE* modes are desired, we now properly supply the timestamp scale value as the timestamp "precision".