### PR TITLE
fixed cross-maven workflow not finding PRs past the first page of results

### DIFF
--- a/.github/workflows/cross-maven.yml
+++ b/.github/workflows/cross-maven.yml
@@ -43,14 +43,29 @@ jobs:
         env:
           branch_name: ${{ github.head_ref }}
         run: |
-          curl --silent -X "GET" https://api.github.com/repos/debezium/debezium/pulls | jq '.[] | {branch: .head.ref}' | jq -r '.branch' >> SORTED_PULLS.txt
+          response=$(curl -si -X "GET" --url "https://api.github.com/repos/debezium/debezium/pulls?per_page=100&sort=updated")
+          link_next=$(echo "$response" | grep -oP '(?<=link: <).*(?=>; rel="next")')
+          echo "$response" | sed -n '/\[/,$ p' | jq '.[] | {branch: .head.ref}' | jq -r '.branch' >> SORTED_PULLS.TXT
 
-          while IFS=" " read -r BRANCH;
-          do
-            if grep -q "$branch_name" <<< "$BRANCH"; then
-              echo "BRANCH_FOUND=true" >> $GITHUB_OUTPUT
-            fi
-          done < SORTED_PULLS.txt
+          branch_found=false
+          has_next=true
+          while ! $branch_found && $has_next; do
+              while IFS=" " read -r BRANCH; do
+              if grep -q "$branch_name" <<< "$BRANCH"; then
+                  branch_found=true
+                  echo "BRANCH_FOUND=true" >> $GITHUB_OUTPUT
+              fi
+              done < SORTED_PULLS.txt
+
+              if ! $branch_found && $has_next; then
+                  response=$(curl -si -X "GET" --url "$link_next")
+                  link_next=$(echo "$response" | grep -oP '(?<=rel="prev", <).*(?=>; rel="next")')
+                  if [[ -z $link_next ]]; then
+                      has_next=false
+                  fi
+                  echo "$response" | sed -n '/\[/,$ p' | jq '.[] | {branch: .head.ref}' | jq -r '.branch' > SORTED_PULLS.TXT
+              fi
+          done
       - name: Checkout core repository with pull request branch
         if: ${{ steps.branch.outputs.BRANCH_FOUND == 'true' }}
         uses: actions/checkout@v6

--- a/.github/workflows/cross-maven.yml
+++ b/.github/workflows/cross-maven.yml
@@ -64,7 +64,7 @@ jobs:
 
               if ! $branch_found && $has_next; then
                   response=$(curl -si -X "GET" --url "$link_next")
-                  link_next=$(echo "$response" | grep -oP '(?<=rel="prev", <).*(?=>; rel="next")')
+                  link_next=$(echo "$response" | grep -oP '(?<=rel="prev", <).*(?=>; rel="next")' || true)
                   if [[ ! -z $link_next ]]; then
                     has_next=true
                   else

--- a/.github/workflows/cross-maven.yml
+++ b/.github/workflows/cross-maven.yml
@@ -43,35 +43,32 @@ jobs:
         env:
           branch_name: ${{ github.head_ref }}
         run: |
-          response=$(curl -si -X "GET" --url "https://api.github.com/repos/debezium/debezium/pulls?per_page=100&sort=updated")
-          link_next=$(echo "$response" | grep -oP '(?<=<)[^>]*(?=>; rel="next")' || true)
-          echo "$response" | sed -n '/\[/,$ p' | jq '.[] | {branch: .head.ref}' | jq -r '.branch' >> SORTED_PULLS.txt
+          function get_response {
+              response=$(curl -si -X "GET" --url $1)
+              link_next=$(echo "$response" | grep -oP '(?<=<)[^>]*(?=>; rel="next")' || true)
+              echo "$response" | sed -n '/\[/,$ p' | jq '.[] | {branch: .head.ref}' | jq -r '.branch' >> SORTED_PULLS.txt
+
+              if [[ ! -z $link_next ]]; then
+                  has_next=true
+              else
+                  has_next=false
+              fi
+          }
+
+          get_response "https://api.github.com/repos/debezium/debezium/pulls?per_page=100&sort=updated"
 
           branch_found=false
-          if [[ ! -z $link_next ]]; then
-            has_next=true
-          else
-            has_next=false
-          fi
-
           while ! $branch_found && $has_next; do
-              while IFS=" " read -r BRANCH; do
+            while IFS=" " read -r BRANCH; do
               if [ "$branch_name" = "$BRANCH" ]; then
                 branch_found=true
                 echo "BRANCH_FOUND=true" >> $GITHUB_OUTPUT
               fi
-              done < SORTED_PULLS.txt
+            done < SORTED_PULLS.txt
 
-              if ! $branch_found && $has_next; then
-                  response=$(curl -si -X "GET" --url "$link_next")
-                  link_next=$(echo "$response" | grep -oP '(?<=rel="prev", <).*(?=>; rel="next")' || true)
-                  if [[ ! -z $link_next ]]; then
-                    has_next=true
-                  else
-                    has_next=false
-                  fi
-                  echo "$response" | sed -n '/\[/,$ p' | jq '.[] | {branch: .head.ref}' | jq -r '.branch' >> SORTED_PULLS.txt
-              fi
+            if ! $branch_found && $has_next; then
+              get_response "$link_next"
+            fi
           done
       - name: Checkout core repository with pull request branch
         if: ${{ steps.branch.outputs.BRANCH_FOUND == 'true' }}

--- a/.github/workflows/cross-maven.yml
+++ b/.github/workflows/cross-maven.yml
@@ -43,32 +43,19 @@ jobs:
         env:
           branch_name: ${{ github.head_ref }}
         run: |
-          function get_response {
-              response=$(curl -si -X "GET" --url $1)
-              link_next=$(echo "$response" | grep -oP '(?<=<)[^>]*(?=>; rel="next")' || true)
-              echo "$response" | sed -n '/\[/,$ p' | jq '.[] | {branch: .head.ref}' | jq -r '.branch' >> SORTED_PULLS.txt
-
-              if [[ ! -z $link_next ]]; then
-                  has_next=true
-              else
-                  has_next=false
-              fi
-          }
-
-          get_response "https://api.github.com/repos/debezium/debezium/pulls?per_page=100&sort=updated"
-
+          next_url="https://api.github.com/repos/debezium/debezium/pulls?per_page=100&sort=updated"
           branch_found=false
-          while ! $branch_found && $has_next; do
+          while [ ! -z $next_url ] && ! $branch_found; do
+            response=$(curl -si -X "GET" --url "$next_url")
+            next_url=$(echo "$response" | grep -oP '(?<=<)[^>]*(?=>; rel="next")' || true)
+            echo "$response" | sed -n '/\[/,$ p' | jq -r '.[] | {branch: .head.ref}' | jq -r '.branch' > /tmp/pulls_page.txt
+
             while IFS=" " read -r BRANCH; do
               if [ "$branch_name" = "$BRANCH" ]; then
                 branch_found=true
                 echo "BRANCH_FOUND=true" >> $GITHUB_OUTPUT
               fi
-            done < SORTED_PULLS.txt
-
-            if ! $branch_found && $has_next; then
-              get_response "$link_next"
-            fi
+            done < /tmp/pulls_page.txt
           done
       - name: Checkout core repository with pull request branch
         if: ${{ steps.branch.outputs.BRANCH_FOUND == 'true' }}

--- a/.github/workflows/cross-maven.yml
+++ b/.github/workflows/cross-maven.yml
@@ -44,7 +44,7 @@ jobs:
           branch_name: ${{ github.head_ref }}
         run: |
           response=$(curl -si -X "GET" --url "https://api.github.com/repos/debezium/debezium/pulls?per_page=100&sort=updated")
-          link_next=$(echo "$response" | grep -oP '(?<=link: <).*(?=>; rel="next")')
+          link_next=$(echo "$response" | grep -oP '(?<=<)[^>]*(?=>; rel="next")' || true)
           echo "$response" | sed -n '/\[/,$ p' | jq '.[] | {branch: .head.ref}' | jq -r '.branch' >> SORTED_PULLS.txt
 
           branch_found=false
@@ -56,7 +56,7 @@ jobs:
 
           while ! $branch_found && $has_next; do
               while IFS=" " read -r BRANCH; do
-              if grep -q "$branch_name" <<< "$BRANCH"; then
+              if [ "$branch_name" = "$BRANCH" ]; then
                 branch_found=true
                 echo "BRANCH_FOUND=true" >> $GITHUB_OUTPUT
               fi

--- a/.github/workflows/cross-maven.yml
+++ b/.github/workflows/cross-maven.yml
@@ -45,25 +45,32 @@ jobs:
         run: |
           response=$(curl -si -X "GET" --url "https://api.github.com/repos/debezium/debezium/pulls?per_page=100&sort=updated")
           link_next=$(echo "$response" | grep -oP '(?<=link: <).*(?=>; rel="next")')
-          echo "$response" | sed -n '/\[/,$ p' | jq '.[] | {branch: .head.ref}' | jq -r '.branch' >> SORTED_PULLS.TXT
+          echo "$response" | sed -n '/\[/,$ p' | jq '.[] | {branch: .head.ref}' | jq -r '.branch' >> SORTED_PULLS.txt
 
           branch_found=false
-          has_next=true
+          if [[ ! -z $link_next ]]; then
+            has_next=true
+          else
+            has_next=false
+          fi
+
           while ! $branch_found && $has_next; do
               while IFS=" " read -r BRANCH; do
               if grep -q "$branch_name" <<< "$BRANCH"; then
-                  branch_found=true
-                  echo "BRANCH_FOUND=true" >> $GITHUB_OUTPUT
+                branch_found=true
+                echo "BRANCH_FOUND=true" >> $GITHUB_OUTPUT
               fi
               done < SORTED_PULLS.txt
 
               if ! $branch_found && $has_next; then
                   response=$(curl -si -X "GET" --url "$link_next")
                   link_next=$(echo "$response" | grep -oP '(?<=rel="prev", <).*(?=>; rel="next")')
-                  if [[ -z $link_next ]]; then
-                      has_next=false
+                  if [[ ! -z $link_next ]]; then
+                    has_next=true
+                  else
+                    has_next=false
                   fi
-                  echo "$response" | sed -n '/\[/,$ p' | jq '.[] | {branch: .head.ref}' | jq -r '.branch' > SORTED_PULLS.TXT
+                  echo "$response" | sed -n '/\[/,$ p' | jq '.[] | {branch: .head.ref}' | jq -r '.branch' >> SORTED_PULLS.txt
               fi
           done
       - name: Checkout core repository with pull request branch


### PR DESCRIPTION
The maximum `per_page` value that you can have when using the github API is 100, so combining that with sorting by updated instead of created PRs should mean that most of the time just one request is needed. If the PR is not found on the first page of results then the next page is retrieved and checked until either the PR is found or there are no pages left.